### PR TITLE
Strictify user views

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xl_auth 0.6.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-12-04 16:33+0100\n"
+"POT-Creation-Date: 2017-12-07 11:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,9 +113,10 @@ msgstr ""
 #: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
 #: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
 #: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
-#: tests/end2end/test_user_editing.py:197 xl_auth/templates/collections/view.html:54
+#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
+#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:54
 #: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
-#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:42
+#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:52
 msgid "Permissions"
 msgstr ""
 
@@ -216,10 +217,10 @@ msgstr ""
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/view.html:15 xl_auth/templates/users/view.html:18
-#: xl_auth/templates/users/view.html:21 xl_auth/templates/users/view.html:64
-#: xl_auth/templates/users/view.html:67 xl_auth/templates/users/view.html:70
-#: xl_auth/templates/users/view.html:73
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
+#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
+#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "Yes"
 msgstr ""
 
@@ -234,10 +235,10 @@ msgstr ""
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/view.html:15 xl_auth/templates/users/view.html:18
-#: xl_auth/templates/users/view.html:21 xl_auth/templates/users/view.html:64
-#: xl_auth/templates/users/view.html:67 xl_auth/templates/users/view.html:70
-#: xl_auth/templates/users/view.html:73
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
+#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
+#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "No"
 msgstr ""
 
@@ -254,15 +255,16 @@ msgid "Email cannot be modified"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:160 xl_auth/templates/users/inspect.html:8
-#: xl_auth/templates/users/view.html:8 xl_auth/user/forms.py:14
+#: xl_auth/templates/users/simple_view.html:8 xl_auth/templates/users/view.html:8
+#: xl_auth/user/forms.py:14
 msgid "Full name"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:178 tests/end2end/test_user_editing.py:182
-#: tests/end2end/test_user_inspection.py:63 tests/end2end/test_user_view.py:46
+#: tests/end2end/test_user_inspection.py:63 tests/end2end/test_user_view.py:48
 #: tests/forms/test_permission_edit.py:62 tests/forms/test_permission_register.py:46
-#: xl_auth/permission/forms.py:41 xl_auth/user/views.py:90 xl_auth/user/views.py:105
-#: xl_auth/user/views.py:140 xl_auth/user/views.py:167 xl_auth/user/views.py:195
+#: xl_auth/permission/forms.py:41 xl_auth/user/views.py:90 xl_auth/user/views.py:109
+#: xl_auth/user/views.py:144 xl_auth/user/views.py:171 xl_auth/user/views.py:199
 #, python-format
 msgid "User ID \"%(user_id)s\" does not exist"
 msgstr ""
@@ -292,9 +294,14 @@ msgstr ""
 msgid "Email already registered"
 msgstr ""
 
-#: tests/end2end/test_user_view.py:27 xl_auth/templates/users/view.html:4
+#: tests/end2end/test_user_view.py:29 xl_auth/templates/users/simple_view.html:4
+#: xl_auth/templates/users/view.html:4
 #, python-format
 msgid "View User '%(email)s'"
+msgstr ""
+
+#: tests/end2end/test_user_view.py:142 tests/models/test_user.py:231 xl_auth/user/models.py:186
+msgid "You will only see permissions for those collections that you are cataloging administrator for."
 msgstr ""
 
 #: tests/forms/test_client_edit.py:23 tests/forms/test_client_register.py:25
@@ -447,26 +454,26 @@ msgid "User"
 msgstr ""
 
 #: xl_auth/permission/forms.py:20 xl_auth/templates/permissions/home.html:17
-#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:47
+#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:60
 msgid "Collection"
 msgstr ""
 
 #: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:60
 #: xl_auth/templates/permissions/home.html:18 xl_auth/templates/users/inspect.html:72
-#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:48
+#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:61
 msgid "Registrant"
 msgstr ""
 
 #: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:61
 #: xl_auth/templates/permissions/home.html:19 xl_auth/templates/users/inspect.html:73
-#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:49
+#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:62
 msgid "Cataloger"
 msgstr ""
 
 #: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:62
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
 #: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:52
-#: xl_auth/templates/users/view.html:20 xl_auth/templates/users/view.html:50
+#: xl_auth/templates/users/view.html:20 xl_auth/templates/users/view.html:63
 msgid "Cataloguing Administrator"
 msgstr ""
 
@@ -614,7 +621,7 @@ msgstr ""
 
 #: xl_auth/templates/collections/view.html:35 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
-#: xl_auth/templates/users/view.html:23 xl_auth/templates/users/view.html:52
+#: xl_auth/templates/users/view.html:23 xl_auth/templates/users/view.html:65
 msgid "Last Modified"
 msgstr ""
 
@@ -622,7 +629,7 @@ msgstr ""
 #: xl_auth/templates/collections/view.html:83 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
 #: xl_auth/templates/users/view.html:25 xl_auth/templates/users/view.html:33
-#: xl_auth/templates/users/view.html:75
+#: xl_auth/templates/users/view.html:89
 msgid "by"
 msgstr ""
 
@@ -879,7 +886,8 @@ msgstr ""
 msgid "Inactive Users"
 msgstr ""
 
-#: xl_auth/templates/users/inspect.html:14 xl_auth/templates/users/view.html:14
+#: xl_auth/templates/users/inspect.html:14 xl_auth/templates/users/simple_view.html:11
+#: xl_auth/templates/users/view.html:14
 msgid "Active Account"
 msgstr ""
 
@@ -920,7 +928,7 @@ msgstr ""
 msgid "Clients Modified"
 msgstr ""
 
-#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:51
+#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:64
 msgid "Active Collection"
 msgstr ""
 
@@ -970,6 +978,10 @@ msgstr ""
 
 #: xl_auth/templates/users/register.html:15
 msgid "First Last"
+msgstr ""
+
+#: xl_auth/templates/users/simple_view.html:14 xl_auth/templates/users/view.html:39
+msgid "Cataloging admin for"
 msgstr ""
 
 #: xl_auth/user/forms.py:20
@@ -1024,12 +1036,12 @@ msgstr ""
 msgid "User \"%(username)s\" registered."
 msgstr ""
 
-#: xl_auth/user/views.py:149 xl_auth/user/views.py:173
+#: xl_auth/user/views.py:153 xl_auth/user/views.py:177
 #, python-format
 msgid "Thank you for updating user details for \"%(username)s\"."
 msgstr ""
 
-#: xl_auth/user/views.py:202
+#: xl_auth/user/views.py:206
 #, python-format
 msgid "Thank you for changing password for \"%(username)s\"."
 msgstr ""

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xl_auth 0.6.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-12-07 11:12+0100\n"
+"POT-Creation-Date: 2017-12-07 14:44+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -217,8 +217,8 @@ msgstr ""
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
-#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
+#: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
 #: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "Yes"
@@ -235,8 +235,8 @@ msgstr ""
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
-#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
+#: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
 #: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "No"
@@ -300,7 +300,7 @@ msgstr ""
 msgid "View User '%(email)s'"
 msgstr ""
 
-#: tests/end2end/test_user_view.py:142 tests/models/test_user.py:231 xl_auth/user/models.py:186
+#: tests/end2end/test_user_view.py:145 tests/models/test_user.py:234 xl_auth/user/models.py:186
 msgid "You will only see permissions for those collections that you are cataloging administrator for."
 msgstr ""
 
@@ -473,7 +473,7 @@ msgstr ""
 #: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:62
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
 #: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:52
-#: xl_auth/templates/users/view.html:20 xl_auth/templates/users/view.html:63
+#: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:63
 msgid "Cataloguing Administrator"
 msgstr ""
 
@@ -582,7 +582,7 @@ msgstr ""
 #: xl_auth/templates/collections/view.html:43 xl_auth/templates/collections/view.html:63
 #: xl_auth/templates/permissions/home.html:21 xl_auth/templates/users/home.html:22
 #: xl_auth/templates/users/home.html:75 xl_auth/templates/users/inspect.html:55
-#: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:31
+#: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:22
 msgid "Created At"
 msgstr ""
 
@@ -621,14 +621,14 @@ msgstr ""
 
 #: xl_auth/templates/collections/view.html:35 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
-#: xl_auth/templates/users/view.html:23 xl_auth/templates/users/view.html:65
+#: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:65
 msgid "Last Modified"
 msgstr ""
 
 #: xl_auth/templates/collections/view.html:37 xl_auth/templates/collections/view.html:45
 #: xl_auth/templates/collections/view.html:83 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
-#: xl_auth/templates/users/view.html:25 xl_auth/templates/users/view.html:33
+#: xl_auth/templates/users/view.html:16 xl_auth/templates/users/view.html:24
 #: xl_auth/templates/users/view.html:89
 msgid "by"
 msgstr ""
@@ -887,13 +887,13 @@ msgid "Inactive Users"
 msgstr ""
 
 #: xl_auth/templates/users/inspect.html:14 xl_auth/templates/users/simple_view.html:11
-#: xl_auth/templates/users/view.html:14
+#: xl_auth/templates/users/view.html:30
 msgid "Active Account"
 msgstr ""
 
-#: xl_auth/templates/users/inspect.html:17 xl_auth/templates/users/view.html:17
+#: xl_auth/templates/users/inspect.html:17 xl_auth/templates/users/view.html:33
 #: xl_auth/user/forms.py:141
-msgid "Administrator"
+msgid "System Administrator"
 msgstr ""
 
 #: xl_auth/templates/users/inspect.html:23

--- a/xl_auth/templates/users/inspect.html
+++ b/xl_auth/templates/users/inspect.html
@@ -14,7 +14,7 @@
             <dt>{{ _('Active Account') }}:</dt>
             <dd>{{ _('Yes') if user.is_active else _('No') }}</dd>
 
-            <dt>{{ _('Administrator') }}:</dt>
+            <dt>{{ _('System Administrator') }}:</dt>
             <dd>{{ _('Yes') if user.is_admin else _('No') }}</dd>
 
             <dt>{{ _('Cataloguing Administrator') }}:</dt>

--- a/xl_auth/templates/users/simple_view.html
+++ b/xl_auth/templates/users/simple_view.html
@@ -1,0 +1,25 @@
+<!-- users/simple_view.html -->
+{% extends "layout.html" %}
+{% block content %}
+    <h1>{{ _('View User \'%(email)s\'', email=user.email) }}</h1>
+    <br/>
+    <div class="panel panel-default">
+        <dl class="dl-horizontal">
+            <dt>{{ _('Full name') }}:</dt>
+            <dd>{{ user.full_name }}</dd>
+
+            <dt>{{ _('Active Account') }}:</dt>
+            <dd>{{ _('Yes') if user.is_active else _('No') }}</dd>
+
+            <dt>{{ _('Cataloging admin for') }}:</dt>
+            <dd>
+                {% for permission in user.get_cataloging_admin_permissions()
+                        | sort(attribute='collection.code') %}
+                    <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}">
+                        {{ permission.collection.code }}
+                    </a>
+                {% endfor %}
+            </dd>
+        </dl>
+    </div>
+{% endblock %}

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -35,11 +35,24 @@
                     {{ user.created_by.full_name }}
                 </a>
             </dd>
+
+            <dt>{{ _('Cataloging admin for') }}:</dt>
+            <dd>
+                {% for permission in user.get_cataloging_admin_permissions()
+                        | sort(attribute='collection.code') %}
+                    <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}">
+                        {{ permission.collection.code }}
+                    </a>
+                {% endfor %}
+            </dd>
         </dl>
     </div>
     <div class="panel panel-default">
         <div class="panel-heading">
-            <strong>{{ user.get_permissions_label_as_seen_by(current_user) }}</strong>
+            <strong>{{ _('Permissions') }}</strong>
+            {% if user.get_permissions_label_help_text_as_seen_by(current_user) != '' %}
+                <span>({{ user.get_permissions_label_help_text_as_seen_by(current_user) }})</span>
+            {% endif %}
         </div>
         <table class="table table-hover">
             <thead>

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -11,15 +11,6 @@
             <dt>{{ _('Last Login At') }}:</dt>
             <dd>{{ '-' if not user.last_login_at else user.last_login_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}</dd>
 
-            <dt>{{ _('Active Account') }}:</dt>
-            <dd>{{ _('Yes') if user.is_active else _('No') }}</dd>
-
-            <dt>{{ _('Administrator') }}:</dt>
-            <dd>{{ _('Yes') if user.is_admin else _('No') }}</dd>
-
-            <dt>{{ _('Cataloguing Administrator') }}:</dt>
-            <dd>{{ _('Yes') if user.is_cataloging_admin else _('No') }}</dd>
-
             <dt>{{ _('Last Modified') }}:</dt>
             <dd>
                 {{ user.modified_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}, {{  _('by') }}
@@ -35,6 +26,15 @@
                     {{ user.created_by.full_name }}
                 </a>
             </dd>
+
+            <dt>{{ _('Active Account') }}:</dt>
+            <dd>{{ _('Yes') if user.is_active else _('No') }}</dd>
+
+            <dt>{{ _('System Administrator') }}:</dt>
+            <dd>{{ _('Yes') if user.is_admin else _('No') }}</dd>
+
+            <dt>{{ _('Cataloguing Administrator') }}:</dt>
+            <dd>{{ _('Yes') if user.is_cataloging_admin else _('No') }}</dd>
 
             <dt>{{ _('Cataloging admin for') }}:</dt>
             <dd>

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.2.1\n"
 "Report-Msgid-Bugs-To: mats.blomdahl@gmail.com\n"
-"POT-Creation-Date: 2017-12-07 11:12+0100\n"
+"POT-Creation-Date: 2017-12-07 14:44+0100\n"
 "PO-Revision-Date: 2017-09-19 12:23+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
@@ -218,8 +218,8 @@ msgstr "Användare"
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
-#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
+#: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
 #: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "Yes"
@@ -236,8 +236,8 @@ msgstr "Ja"
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
-#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
+#: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
 #: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "No"
@@ -301,7 +301,7 @@ msgstr "Epost-adressen är redan registrerad"
 msgid "View User '%(email)s'"
 msgstr "Användare '%(email)s'"
 
-#: tests/end2end/test_user_view.py:142 tests/models/test_user.py:231 xl_auth/user/models.py:186
+#: tests/end2end/test_user_view.py:145 tests/models/test_user.py:234 xl_auth/user/models.py:186
 msgid "You will only see permissions for those collections that you are cataloging administrator for."
 msgstr "Du kommer enbart se rättigheter knutna till de sigel du är katalogiseringsadministratör för."
 
@@ -474,7 +474,7 @@ msgstr "Katalogisatör"
 #: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:62
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
 #: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:52
-#: xl_auth/templates/users/view.html:20 xl_auth/templates/users/view.html:63
+#: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:63
 msgid "Cataloguing Administrator"
 msgstr "Katalogiseringsadmin"
 
@@ -583,7 +583,7 @@ msgstr "Namn"
 #: xl_auth/templates/collections/view.html:43 xl_auth/templates/collections/view.html:63
 #: xl_auth/templates/permissions/home.html:21 xl_auth/templates/users/home.html:22
 #: xl_auth/templates/users/home.html:75 xl_auth/templates/users/inspect.html:55
-#: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:31
+#: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:22
 msgid "Created At"
 msgstr "Skapad"
 
@@ -622,14 +622,14 @@ msgstr "Ersätter"
 
 #: xl_auth/templates/collections/view.html:35 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
-#: xl_auth/templates/users/view.html:23 xl_auth/templates/users/view.html:65
+#: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:65
 msgid "Last Modified"
 msgstr "Ändrad"
 
 #: xl_auth/templates/collections/view.html:37 xl_auth/templates/collections/view.html:45
 #: xl_auth/templates/collections/view.html:83 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
-#: xl_auth/templates/users/view.html:25 xl_auth/templates/users/view.html:33
+#: xl_auth/templates/users/view.html:16 xl_auth/templates/users/view.html:24
 #: xl_auth/templates/users/view.html:89
 msgid "by"
 msgstr "av"
@@ -895,14 +895,14 @@ msgid "Inactive Users"
 msgstr "Inaktiva användare"
 
 #: xl_auth/templates/users/inspect.html:14 xl_auth/templates/users/simple_view.html:11
-#: xl_auth/templates/users/view.html:14
+#: xl_auth/templates/users/view.html:30
 msgid "Active Account"
 msgstr "Konto aktivt"
 
-#: xl_auth/templates/users/inspect.html:17 xl_auth/templates/users/view.html:17
+#: xl_auth/templates/users/inspect.html:17 xl_auth/templates/users/view.html:33
 #: xl_auth/user/forms.py:141
-msgid "Administrator"
-msgstr "Administratör"
+msgid "System Administrator"
+msgstr "Systemadministratör"
 
 #: xl_auth/templates/users/inspect.html:23
 msgid "Users Created"

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.2.1\n"
 "Report-Msgid-Bugs-To: mats.blomdahl@gmail.com\n"
-"POT-Creation-Date: 2017-12-04 16:33+0100\n"
+"POT-Creation-Date: 2017-12-07 11:12+0100\n"
 "PO-Revision-Date: 2017-09-19 12:23+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
@@ -114,9 +114,10 @@ msgstr "Ny klient"
 #: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
 #: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
 #: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
-#: tests/end2end/test_user_editing.py:197 xl_auth/templates/collections/view.html:54
+#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
+#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:54
 #: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
-#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:42
+#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:52
 msgid "Permissions"
 msgstr "Behörigheter"
 
@@ -217,10 +218,10 @@ msgstr "Användare"
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/view.html:15 xl_auth/templates/users/view.html:18
-#: xl_auth/templates/users/view.html:21 xl_auth/templates/users/view.html:64
-#: xl_auth/templates/users/view.html:67 xl_auth/templates/users/view.html:70
-#: xl_auth/templates/users/view.html:73
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
+#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
+#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "Yes"
 msgstr "Ja"
 
@@ -235,10 +236,10 @@ msgstr "Ja"
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
 #: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
-#: xl_auth/templates/users/view.html:15 xl_auth/templates/users/view.html:18
-#: xl_auth/templates/users/view.html:21 xl_auth/templates/users/view.html:64
-#: xl_auth/templates/users/view.html:67 xl_auth/templates/users/view.html:70
-#: xl_auth/templates/users/view.html:73
+#: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:15
+#: xl_auth/templates/users/view.html:18 xl_auth/templates/users/view.html:21
+#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
+#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
 msgid "No"
 msgstr "Nej"
 
@@ -255,15 +256,16 @@ msgid "Email cannot be modified"
 msgstr "Epost/användarnamn går inte att ändra"
 
 #: tests/end2end/test_user_editing.py:160 xl_auth/templates/users/inspect.html:8
-#: xl_auth/templates/users/view.html:8 xl_auth/user/forms.py:14
+#: xl_auth/templates/users/simple_view.html:8 xl_auth/templates/users/view.html:8
+#: xl_auth/user/forms.py:14
 msgid "Full name"
 msgstr "Fullständigt namn"
 
 #: tests/end2end/test_user_editing.py:178 tests/end2end/test_user_editing.py:182
-#: tests/end2end/test_user_inspection.py:63 tests/end2end/test_user_view.py:46
+#: tests/end2end/test_user_inspection.py:63 tests/end2end/test_user_view.py:48
 #: tests/forms/test_permission_edit.py:62 tests/forms/test_permission_register.py:46
-#: xl_auth/permission/forms.py:41 xl_auth/user/views.py:90 xl_auth/user/views.py:105
-#: xl_auth/user/views.py:140 xl_auth/user/views.py:167 xl_auth/user/views.py:195
+#: xl_auth/permission/forms.py:41 xl_auth/user/views.py:90 xl_auth/user/views.py:109
+#: xl_auth/user/views.py:144 xl_auth/user/views.py:171 xl_auth/user/views.py:199
 #, python-format
 msgid "User ID \"%(user_id)s\" does not exist"
 msgstr "Användare med databas-ID \"%(user_id)s\" existerar inte"
@@ -293,10 +295,15 @@ msgstr "Ny användare"
 msgid "Email already registered"
 msgstr "Epost-adressen är redan registrerad"
 
-#: tests/end2end/test_user_view.py:27 xl_auth/templates/users/view.html:4
+#: tests/end2end/test_user_view.py:29 xl_auth/templates/users/simple_view.html:4
+#: xl_auth/templates/users/view.html:4
 #, python-format
 msgid "View User '%(email)s'"
 msgstr "Användare '%(email)s'"
+
+#: tests/end2end/test_user_view.py:142 tests/models/test_user.py:231 xl_auth/user/models.py:186
+msgid "You will only see permissions for those collections that you are cataloging administrator for."
+msgstr "Du kommer enbart se rättigheter knutna till de sigel du är katalogiseringsadministratör för."
 
 #: tests/forms/test_client_edit.py:23 tests/forms/test_client_register.py:25
 #: tests/forms/test_collection_edit.py:67 tests/forms/test_collection_register.py:79
@@ -448,26 +455,26 @@ msgid "User"
 msgstr "Användare"
 
 #: xl_auth/permission/forms.py:20 xl_auth/templates/permissions/home.html:17
-#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:47
+#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:60
 msgid "Collection"
 msgstr "Sigel"
 
 #: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:60
 #: xl_auth/templates/permissions/home.html:18 xl_auth/templates/users/inspect.html:72
-#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:48
+#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:61
 msgid "Registrant"
 msgstr "Beståndsregistrerare"
 
 #: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:61
 #: xl_auth/templates/permissions/home.html:19 xl_auth/templates/users/inspect.html:73
-#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:49
+#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:62
 msgid "Cataloger"
 msgstr "Katalogisatör"
 
 #: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:62
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
 #: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:52
-#: xl_auth/templates/users/view.html:20 xl_auth/templates/users/view.html:50
+#: xl_auth/templates/users/view.html:20 xl_auth/templates/users/view.html:63
 msgid "Cataloguing Administrator"
 msgstr "Katalogiseringsadmin"
 
@@ -615,7 +622,7 @@ msgstr "Ersätter"
 
 #: xl_auth/templates/collections/view.html:35 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
-#: xl_auth/templates/users/view.html:23 xl_auth/templates/users/view.html:52
+#: xl_auth/templates/users/view.html:23 xl_auth/templates/users/view.html:65
 msgid "Last Modified"
 msgstr "Ändrad"
 
@@ -623,7 +630,7 @@ msgstr "Ändrad"
 #: xl_auth/templates/collections/view.html:83 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
 #: xl_auth/templates/users/view.html:25 xl_auth/templates/users/view.html:33
-#: xl_auth/templates/users/view.html:75
+#: xl_auth/templates/users/view.html:89
 msgid "by"
 msgstr "av"
 
@@ -887,7 +894,8 @@ msgstr "Ändra profil"
 msgid "Inactive Users"
 msgstr "Inaktiva användare"
 
-#: xl_auth/templates/users/inspect.html:14 xl_auth/templates/users/view.html:14
+#: xl_auth/templates/users/inspect.html:14 xl_auth/templates/users/simple_view.html:11
+#: xl_auth/templates/users/view.html:14
 msgid "Active Account"
 msgstr "Konto aktivt"
 
@@ -928,7 +936,7 @@ msgstr "OAuth2-klienter skapade"
 msgid "Clients Modified"
 msgstr "OAuth2-klienter ändrade"
 
-#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:51
+#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:64
 msgid "Active Collection"
 msgstr "Sigel aktivt"
 
@@ -984,6 +992,10 @@ msgstr "Registrera ny användare"
 #: xl_auth/templates/users/register.html:15
 msgid "First Last"
 msgstr "Förnamn Efternamn"
+
+#: xl_auth/templates/users/simple_view.html:14 xl_auth/templates/users/view.html:39
+msgid "Cataloging admin for"
+msgstr "Ansvarig för"
 
 #: xl_auth/user/forms.py:20
 msgid "ToS Approved"
@@ -1052,12 +1064,12 @@ msgstr "Användaren \"%(username)s\" har registrerats och mailats en lösenords�
 msgid "User \"%(username)s\" registered."
 msgstr "Användaren \"%(username)s\" har registrerats."
 
-#: xl_auth/user/views.py:149 xl_auth/user/views.py:173
+#: xl_auth/user/views.py:153 xl_auth/user/views.py:177
 #, python-format
 msgid "Thank you for updating user details for \"%(username)s\"."
 msgstr "Användarinställningar uppdaterade för \"%(username)s\"."
 
-#: xl_auth/user/views.py:202
+#: xl_auth/user/views.py:206
 #, python-format
 msgid "Thank you for changing password for \"%(username)s\"."
 msgstr "Lösenord för \"%(username)s\" har ändrats."

--- a/xl_auth/user/forms.py
+++ b/xl_auth/user/forms.py
@@ -138,7 +138,7 @@ class AdministerForm(_EditForm):
 
     full_name = full_name
     is_active = BooleanField(_('Active'))
-    is_admin = BooleanField(_('Administrator'))
+    is_admin = BooleanField(_('System Administrator'))
 
     def validate(self):
         """Validate the form."""

--- a/xl_auth/user/views.py
+++ b/xl_auth/user/views.py
@@ -91,7 +91,7 @@ def view(user_id):
         return redirect(url_for('user.profile'))
     else:
         # Cataloging admins and admins need to see more information, so they get their own view.
-        if current_user.is_admin or len(current_user.get_cataloging_admin_permissions()) > 0:
+        if current_user.is_admin or current_user.is_cataloging_admin:
             return render_template('users/view.html', user=user)
         else:
             return render_template('users/simple_view.html', user=user)

--- a/xl_auth/user/views.py
+++ b/xl_auth/user/views.py
@@ -90,7 +90,11 @@ def view(user_id):
         flash(_('User ID "%(user_id)s" does not exist', user_id=user_id), 'danger')
         return redirect(url_for('user.profile'))
     else:
-        return render_template('users/view.html', user=user)
+        # Cataloging admins and admins need to see more information, so they get their own view.
+        if current_user.is_admin or len(current_user.get_cataloging_admin_permissions()) > 0:
+            return render_template('users/view.html', user=user)
+        else:
+            return render_template('users/simple_view.html', user=user)
 
 
 @blueprint.route('/inspect/<int:user_id>', methods=['GET'])


### PR DESCRIPTION
* Superusers can see everything
* Regular users can see their own permissions...
* ...and the collection codes for another user's cataloging admin
  permissions
* Cataloging admins can see all permissions for those collections they
  are responsible for.