### PR TITLE
Feature/109 CR fixes #2

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -306,7 +306,7 @@ msgid "View User '%(email)s'"
 msgstr ""
 
 #: tests/end2end/test_user_view.py:145 tests/models/test_user.py:234 xl_auth/user/models.py:186
-msgid "You will only see permissions for those collections that you are cataloging administrator for."
+msgid "You will only see all permissions for those collections that you are cataloging administrator for."
 msgstr ""
 
 #: tests/forms/test_client_edit.py:23 tests/forms/test_client_register.py:25

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xl_auth 0.6.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-12-07 16:25+0100\n"
+"POT-Creation-Date: 2017-12-11 15:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Not a valid choice"
 msgstr ""
 
-#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:45
+#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:43
 #: xl_auth/collection/views.py:57 xl_auth/collection/views.py:72
 #, python-format
 msgid "Collection code \"%(code)s\" does not exist"
@@ -91,25 +91,34 @@ msgstr ""
 msgid "Code \"%(code)s\" already registered"
 msgstr ""
 
-#: tests/end2end/test_collection_view.py:28 xl_auth/templates/collections/view.html:4
+#: tests/end2end/test_collection_view.py:26 xl_auth/templates/collections/view.html:4
 #, python-format
 msgid "View Collection '%(code)s'"
 msgstr ""
 
-#: tests/end2end/test_collection_view.py:63 tests/end2end/test_collection_view.py:91
-#: tests/end2end/test_permission_deleting.py:25 tests/end2end/test_permission_deleting.py:52
-#: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
-#: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
-#: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
-#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
-#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:65
-#: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
-#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:54
+#: tests/end2end/test_collection_view.py:61 tests/end2end/test_collection_view.py:89
+#: tests/end2end/test_collection_view.py:124 tests/end2end/test_collection_view.py:153
+#: tests/end2end/test_collection_view.py:184 tests/end2end/test_permission_deleting.py:25
+#: tests/end2end/test_permission_deleting.py:52 tests/end2end/test_permission_editing.py:29
+#: tests/end2end/test_permission_editing.py:63 tests/end2end/test_permission_editing.py:90
+#: tests/end2end/test_permission_registering.py:25 tests/end2end/test_permission_registering.py:58
+#: tests/end2end/test_permission_registering.py:85 tests/end2end/test_user_editing.py:197
+#: tests/end2end/test_user_view.py:72 tests/end2end/test_user_view.py:98
+#: xl_auth/templates/collections/view.html:70 xl_auth/templates/nav.html:28
+#: xl_auth/templates/permissions/home.html:4 xl_auth/templates/users/inspect.html:66
+#: xl_auth/templates/users/view.html:54
 msgid "Permissions"
 msgstr ""
 
-#: tests/end2end/test_collection_view.py:125 xl_auth/templates/collections/view.html:35
+#: tests/end2end/test_collection_view.py:123 tests/end2end/test_collection_view.py:152
+#: tests/end2end/test_collection_view.py:181 xl_auth/templates/collections/view.html:35
 msgid "Cataloging Admins"
+msgstr ""
+
+#: tests/end2end/test_collection_view.py:125 tests/end2end/test_collection_view.py:154
+#: tests/end2end/test_collection_view.py:185 tests/models/test_collection.py:145
+#: xl_auth/collection/models.py:47
+msgid "You will only see all permissions for those collections that you are cataloging admin for."
 msgstr ""
 
 #: tests/end2end/test_oauth_deleting_client.py:34 xl_auth/oauth/client/views.py:66
@@ -212,16 +221,16 @@ msgid "Users"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
-#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:97 xl_auth/templates/collections/view.html:100
+#: xl_auth/templates/collections/view.html:103 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
 #: xl_auth/templates/users/inspect.html:21 xl_auth/templates/users/inspect.html:88
 #: xl_auth/templates/users/inspect.html:91 xl_auth/templates/users/inspect.html:94
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
-#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:70
-#: xl_auth/templates/users/profile.html:73 xl_auth/templates/users/profile.html:77
+#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
+#: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:73
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
@@ -230,16 +239,16 @@ msgid "Yes"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
-#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:97 xl_auth/templates/collections/view.html:100
+#: xl_auth/templates/collections/view.html:103 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
 #: xl_auth/templates/users/inspect.html:21 xl_auth/templates/users/inspect.html:88
 #: xl_auth/templates/users/inspect.html:91 xl_auth/templates/users/inspect.html:94
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
-#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:70
-#: xl_auth/templates/users/profile.html:73 xl_auth/templates/users/profile.html:77
+#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
+#: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:73
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
@@ -305,8 +314,8 @@ msgstr ""
 msgid "View User '%(email)s'"
 msgstr ""
 
-#: tests/end2end/test_user_view.py:145 tests/models/test_user.py:234 xl_auth/user/models.py:186
-msgid "You will only see all permissions for those collections that you are cataloging administrator for."
+#: tests/end2end/test_user_view.py:145 tests/models/test_user.py:257 xl_auth/user/models.py:198
+msgid "You will only see permissions for those collections that you are cataloging admin for."
 msgstr ""
 
 #: tests/forms/test_client_edit.py:23 tests/forms/test_client_register.py:25
@@ -375,17 +384,17 @@ msgstr ""
 msgid "Field must be between 3 and 255 characters long."
 msgstr ""
 
-#: tests/models/test_collection.py:111 xl_auth/collection/models.py:47
+#: tests/models/test_collection.py:156 xl_auth/collection/models.py:64
 #, python-format
 msgid "Replaces %(replaces_code)s, then replaced by %(replaced_by_code)s"
 msgstr ""
 
-#: tests/models/test_collection.py:114 xl_auth/collection/models.py:50
+#: tests/models/test_collection.py:159 xl_auth/collection/models.py:67
 #, python-format
 msgid "Replaces %(replaces_code)s"
 msgstr ""
 
-#: tests/models/test_collection.py:117 xl_auth/collection/models.py:52
+#: tests/models/test_collection.py:162 xl_auth/collection/models.py:69
 #, python-format
 msgid "Replaced by %(replaced_by_code)s"
 msgstr ""
@@ -452,7 +461,7 @@ msgstr ""
 msgid "Successfully deleted OAuth2 Bearer token \"%(token_id)s\"."
 msgstr ""
 
-#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:70
+#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:80
 #: xl_auth/templates/oauth/grants/home.html:14 xl_auth/templates/oauth/tokens/home.html:14
 #: xl_auth/templates/permissions/home.html:16
 msgid "User"
@@ -463,21 +472,21 @@ msgstr ""
 msgid "Collection"
 msgstr ""
 
-#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:71
+#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:81
 #: xl_auth/templates/permissions/home.html:18 xl_auth/templates/users/inspect.html:72
-#: xl_auth/templates/users/profile.html:52 xl_auth/templates/users/view.html:63
+#: xl_auth/templates/users/profile.html:51 xl_auth/templates/users/view.html:63
 msgid "Registrant"
 msgstr ""
 
-#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:72
+#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:82
 #: xl_auth/templates/permissions/home.html:19 xl_auth/templates/users/inspect.html:73
-#: xl_auth/templates/users/profile.html:53 xl_auth/templates/users/view.html:64
+#: xl_auth/templates/users/profile.html:52 xl_auth/templates/users/view.html:64
 msgid "Cataloger"
 msgstr ""
 
-#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:73
+#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:83
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
-#: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:55
+#: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:53
 #: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:65
 msgid "Cataloging Admin"
 msgstr ""
@@ -584,7 +593,7 @@ msgid "Friendly Name"
 msgstr ""
 
 #: xl_auth/templates/collections/home.html:25 xl_auth/templates/collections/home.html:76
-#: xl_auth/templates/collections/view.html:54 xl_auth/templates/collections/view.html:74
+#: xl_auth/templates/collections/view.html:56 xl_auth/templates/collections/view.html:84
 #: xl_auth/templates/permissions/home.html:21 xl_auth/templates/users/home.html:22
 #: xl_auth/templates/users/home.html:75 xl_auth/templates/users/inspect.html:55
 #: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:22
@@ -594,7 +603,7 @@ msgstr ""
 #: xl_auth/templates/collections/home.html:37 xl_auth/templates/collections/home.html:83
 #: xl_auth/templates/collections/view.html:14 xl_auth/templates/collections/view.html:26
 #: xl_auth/templates/users/home.html:32 xl_auth/templates/users/home.html:85
-#: xl_auth/templates/users/profile.html:62
+#: xl_auth/templates/users/profile.html:60
 msgid "View"
 msgstr ""
 
@@ -624,22 +633,22 @@ msgstr ""
 msgid "Replaces"
 msgstr ""
 
-#: xl_auth/templates/collections/view.html:40
+#: xl_auth/templates/collections/view.html:41
 msgid " and "
 msgstr ""
 
-#: xl_auth/templates/collections/view.html:42
+#: xl_auth/templates/collections/view.html:43
 msgid "None registered, please contact libris@kb.se to create one."
 msgstr ""
 
-#: xl_auth/templates/collections/view.html:46 xl_auth/templates/users/inspect.html:47
+#: xl_auth/templates/collections/view.html:48 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
 #: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:67
 msgid "Last Modified"
 msgstr ""
 
-#: xl_auth/templates/collections/view.html:48 xl_auth/templates/collections/view.html:56
-#: xl_auth/templates/collections/view.html:94 xl_auth/templates/users/inspect.html:49
+#: xl_auth/templates/collections/view.html:50 xl_auth/templates/collections/view.html:58
+#: xl_auth/templates/collections/view.html:105 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
 #: xl_auth/templates/users/view.html:16 xl_auth/templates/users/view.html:24
 #: xl_auth/templates/users/view.html:91
@@ -789,7 +798,7 @@ msgid "Welcome to xl_auth"
 msgstr ""
 
 #: xl_auth/templates/public/home.html:10 xl_auth/templates/public/home.html:27
-msgid "This is an early beta release of Libris authorization service."
+msgid "This is a beta release of Libris authorization service."
 msgstr ""
 
 #: xl_auth/templates/public/home.html:13 xl_auth/templates/public/home.html:30
@@ -972,7 +981,7 @@ msgstr ""
 #: xl_auth/templates/users/profile.html:30
 msgid ""
 "If you are missing a permission or any of the permissions below are incorrect, please contact the"
-" cataloging administrator for that collection."
+" cataloging admin for that collection."
 msgstr ""
 
 #: xl_auth/templates/users/profile.html:32

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xl_auth 0.6.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-12-07 14:44+0100\n"
+"POT-Creation-Date: 2017-12-07 15:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Not a valid choice"
 msgstr ""
 
-#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:41
+#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:45
 #: xl_auth/collection/views.py:57 xl_auth/collection/views.py:72
 #, python-format
 msgid "Collection code \"%(code)s\" does not exist"
@@ -91,9 +91,25 @@ msgstr ""
 msgid "Code \"%(code)s\" already registered"
 msgstr ""
 
-#: tests/end2end/test_collection_view.py:24 xl_auth/templates/collections/view.html:4
+#: tests/end2end/test_collection_view.py:28 xl_auth/templates/collections/view.html:4
 #, python-format
 msgid "View Collection '%(code)s'"
+msgstr ""
+
+#: tests/end2end/test_collection_view.py:63 tests/end2end/test_collection_view.py:91
+#: tests/end2end/test_permission_deleting.py:25 tests/end2end/test_permission_deleting.py:52
+#: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
+#: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
+#: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
+#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
+#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:65
+#: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
+#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:54
+msgid "Permissions"
+msgstr ""
+
+#: tests/end2end/test_collection_view.py:125 xl_auth/templates/collections/view.html:35
+msgid "Cataloging Admins"
 msgstr ""
 
 #: tests/end2end/test_oauth_deleting_client.py:34 xl_auth/oauth/client/views.py:66
@@ -107,17 +123,6 @@ msgstr ""
 
 #: tests/end2end/test_oauth_registering_client.py:31 xl_auth/templates/oauth/clients/home.html:11
 msgid "New Client"
-msgstr ""
-
-#: tests/end2end/test_permission_deleting.py:25 tests/end2end/test_permission_deleting.py:52
-#: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
-#: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
-#: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
-#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
-#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:54
-#: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
-#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:52
-msgid "Permissions"
 msgstr ""
 
 #: tests/end2end/test_permission_deleting.py:31 xl_auth/templates/permissions/edit.html:7
@@ -207,8 +212,8 @@ msgid "Users"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:75 xl_auth/templates/collections/view.html:78
-#: xl_auth/templates/collections/view.html:81 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
+#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
@@ -219,14 +224,14 @@ msgstr ""
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
-#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
-#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
+#: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
+#: xl_auth/templates/users/view.html:86 xl_auth/templates/users/view.html:89
 msgid "Yes"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:75 xl_auth/templates/collections/view.html:78
-#: xl_auth/templates/collections/view.html:81 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
+#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
@@ -237,8 +242,8 @@ msgstr ""
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
-#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
-#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
+#: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
+#: xl_auth/templates/users/view.html:86 xl_auth/templates/users/view.html:89
 msgid "No"
 msgstr ""
 
@@ -447,34 +452,34 @@ msgstr ""
 msgid "Successfully deleted OAuth2 Bearer token \"%(token_id)s\"."
 msgstr ""
 
-#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:59
+#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:70
 #: xl_auth/templates/oauth/grants/home.html:14 xl_auth/templates/oauth/tokens/home.html:14
 #: xl_auth/templates/permissions/home.html:16
 msgid "User"
 msgstr ""
 
 #: xl_auth/permission/forms.py:20 xl_auth/templates/permissions/home.html:17
-#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:60
+#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:62
 msgid "Collection"
 msgstr ""
 
-#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:60
+#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:71
 #: xl_auth/templates/permissions/home.html:18 xl_auth/templates/users/inspect.html:72
-#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:61
+#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:63
 msgid "Registrant"
 msgstr ""
 
-#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:61
+#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:72
 #: xl_auth/templates/permissions/home.html:19 xl_auth/templates/users/inspect.html:73
-#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:62
+#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:64
 msgid "Cataloger"
 msgstr ""
 
-#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:62
+#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:73
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
 #: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:52
-#: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:63
-msgid "Cataloguing Administrator"
+#: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:65
+msgid "Cataloging Admin"
 msgstr ""
 
 #: xl_auth/permission/forms.py:78
@@ -579,7 +584,7 @@ msgid "Friendly Name"
 msgstr ""
 
 #: xl_auth/templates/collections/home.html:25 xl_auth/templates/collections/home.html:76
-#: xl_auth/templates/collections/view.html:43 xl_auth/templates/collections/view.html:63
+#: xl_auth/templates/collections/view.html:54 xl_auth/templates/collections/view.html:74
 #: xl_auth/templates/permissions/home.html:21 xl_auth/templates/users/home.html:22
 #: xl_auth/templates/users/home.html:75 xl_auth/templates/users/inspect.html:55
 #: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:22
@@ -619,17 +624,25 @@ msgstr ""
 msgid "Replaces"
 msgstr ""
 
-#: xl_auth/templates/collections/view.html:35 xl_auth/templates/users/inspect.html:47
+#: xl_auth/templates/collections/view.html:40
+msgid " and "
+msgstr ""
+
+#: xl_auth/templates/collections/view.html:42
+msgid "None registered, please contact libris@kb.se to create one."
+msgstr ""
+
+#: xl_auth/templates/collections/view.html:46 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
-#: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:65
+#: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:67
 msgid "Last Modified"
 msgstr ""
 
-#: xl_auth/templates/collections/view.html:37 xl_auth/templates/collections/view.html:45
-#: xl_auth/templates/collections/view.html:83 xl_auth/templates/users/inspect.html:49
+#: xl_auth/templates/collections/view.html:48 xl_auth/templates/collections/view.html:56
+#: xl_auth/templates/collections/view.html:94 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
 #: xl_auth/templates/users/view.html:16 xl_auth/templates/users/view.html:24
-#: xl_auth/templates/users/view.html:89
+#: xl_auth/templates/users/view.html:91
 msgid "by"
 msgstr ""
 
@@ -928,7 +941,7 @@ msgstr ""
 msgid "Clients Modified"
 msgstr ""
 
-#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:64
+#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:66
 msgid "Active Collection"
 msgstr ""
 
@@ -968,7 +981,7 @@ msgstr ""
 
 #: xl_auth/templates/users/profile.html:39
 msgid ""
-"Note: <em>Cataloguing Admin</em> is a new privilege that, in the near future, will allow you to "
+"Note: <em>Cataloging Admin</em> is a new privilege that, in the near future, will allow you to "
 "create new user accounts and grant registrant/cataloger privileges to others. "
 msgstr ""
 

--- a/messages.pot
+++ b/messages.pot
@@ -981,7 +981,7 @@ msgid "First Last"
 msgstr ""
 
 #: xl_auth/templates/users/simple_view.html:14 xl_auth/templates/users/view.html:39
-msgid "Cataloging admin for"
+msgid "Cataloging Admin for"
 msgstr ""
 
 #: xl_auth/user/forms.py:20

--- a/tests/end2end/test_collection_view.py
+++ b/tests/end2end/test_collection_view.py
@@ -122,8 +122,8 @@ def test_cataloging_admin_sees_only_cataloging_admins_on_others_collection(user,
     # Sees a subset of permissions.
     assert _('Cataloging Admins') in res
     assert _('Permissions') in res
-    assert _('You will only see all permissions on those collections that you are '
-             'cataloging administrator for.') in res
+    assert _('You will only see all permissions for those collections that you are '
+             'cataloging admin for.') in res
     assert other_users_non_cataloging_admin_permission.user.email not in res
     assert other_user_with_cataloging_admin_permission.user.email in res
 
@@ -151,8 +151,8 @@ def test_non_cataloging_admin_user_sees_permissions_table_on_collections_they_ha
     # Sees a subset of permissions.
     assert _('Cataloging Admins') in res
     assert _('Permissions') in res
-    assert _('You will only see all permissions on those collections that you are '
-             'cataloging administrator for.') in res
+    assert _('You will only see all permissions for those collections that you are '
+             'cataloging admin for.') in res
     assert cataloging_admin_permission.user.email in res
     assert others_regular_permission.user.email not in res
     assert own_regular_permission.user.email in res
@@ -182,5 +182,5 @@ def test_non_cataloging_admin_users_sees_only_cataloging_admins_on_unassociated_
     assert cataloging_admin_permission.user.email in res
     # Does not see permissions table.
     assert _('Permissions') not in res
-    assert _('You will only see all permissions on those collections that you are '
-             'cataloging administrator for.') not in res
+    assert _('You will only see all permissions for those collections that you are '
+             'cataloging admin for.') not in res

--- a/tests/end2end/test_collection_view.py
+++ b/tests/end2end/test_collection_view.py
@@ -133,10 +133,10 @@ def test_cataloging_admin_sees_only_cataloging_admins_on_others_collection(user,
 def test_non_cataloging_admin_user_sees_permissions_table_on_collections_they_have_permissions_for(
         user, collection, testapp):
     """View own and 'cataloging_admin' permissions on collection thyself is associated with."""
-    raise NotImplementedError('Fix me for PR #109!')
+    raise NotImplementedError('Fix me for PR #120!')
 
 
 def test_non_cataloging_admin_users_sees_only_cataloging_admins_on_unassociated_collections(
         user, collection, testapp):
     """Sees cataloging admins' list only when viewing a collection they are not associated with."""
-    raise NotImplementedError('Fix me for PR #109!')
+    raise NotImplementedError('Fix me for PR #120!')

--- a/tests/end2end/test_collection_view.py
+++ b/tests/end2end/test_collection_view.py
@@ -93,8 +93,8 @@ def test_cataloging_admin_can_view_all_permissions_on_own_collection(user, colle
     assert other_users_non_cataloging_admin_permission.user.email in res
 
 
-def test_cataloging_admin_can_see_only_cataloging_admins_on_others_collection(user, collection,
-                                                                              testapp):
+def test_cataloging_admin_sees_only_cataloging_admins_on_others_collection(user, collection,
+                                                                           testapp):
     """View only 'cataloging_admin' permissions on a collection that you're NOT managing."""
     # Add cataloging admin permission.
     cataloging_admin_permission = PermissionFactory(user=user, collection=collection,
@@ -123,5 +123,20 @@ def test_cataloging_admin_can_see_only_cataloging_admins_on_others_collection(us
     assert res.status_code is 200
     # Sees all permissions.
     assert _('Cataloging Admins') in res
+    assert _('Permissions') in res
+    assert _('You will only see all permissions for those collections that you are '
+             'cataloging administrator for.')
     assert other_users_non_cataloging_admin_permission.user.email not in res
     assert other_user_with_cataloging_admin_permission.user.email in res
+
+
+def test_non_cataloging_admin_user_sees_permissions_table_on_collections_they_have_permissions_for(
+        user, collection, testapp):
+    """View own and 'cataloging_admin' permissions on collection thyself is associated with."""
+    raise NotImplementedError('Fix me for PR #109!')
+
+
+def test_non_cataloging_admin_users_sees_only_cataloging_admins_on_unassociated_collections(
+        user, collection, testapp):
+    """Sees cataloging admins' list only when viewing a collection they are not associated with."""
+    raise NotImplementedError('Fix me for PR #109!')

--- a/tests/end2end/test_user_view.py
+++ b/tests/end2end/test_user_view.py
@@ -142,6 +142,6 @@ def test_user_can_only_view_cataloging_admin_permissions_on_others_when_not_admi
     res = testapp.get(
         url_for('user.view', user_id=another_users_non_cataloging_admin_permission.user.id))
     assert res.status_code is 200
-    assert _('You will only see permissions for those collections that you are cataloging '
+    assert _('You will only see all permissions for those collections that you are cataloging '
              'administrator for.') in res
     assert collection_view_url in res

--- a/tests/end2end/test_user_view.py
+++ b/tests/end2end/test_user_view.py
@@ -142,6 +142,6 @@ def test_user_can_only_view_cataloging_admin_permissions_on_others_when_not_admi
     res = testapp.get(
         url_for('user.view', user_id=another_users_non_cataloging_admin_permission.user.id))
     assert res.status_code is 200
-    assert _('You will only see all permissions for those collections that you are cataloging '
+    assert _('You will only see permissions for those collections that you are cataloging '
              'administrator for.') in res
     assert collection_view_url in res

--- a/tests/end2end/test_user_view.py
+++ b/tests/end2end/test_user_view.py
@@ -143,5 +143,5 @@ def test_user_can_only_view_cataloging_admin_permissions_on_others_when_not_admi
         url_for('user.view', user_id=another_users_non_cataloging_admin_permission.user.id))
     assert res.status_code is 200
     assert _('You will only see permissions for those collections that you are cataloging '
-             'administrator for.') in res
+             'admin for.') in res
     assert collection_view_url in res

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -13,7 +13,7 @@ from xl_auth.collection.models import Collection
 from xl_auth.permission.models import Permission
 from xl_auth.user.models import User
 
-from ..factories import CollectionFactory, SuperUserFactory
+from ..factories import CollectionFactory, SuperUserFactory, UserFactory
 
 
 def test_get_by_id(superuser):
@@ -103,9 +103,39 @@ def test_removing_permissions(superuser, user):
     assert permission not in collection.permissions
 
 
-def test_get_permissions_as_seen_by(user):
+def test_get_permissions_as_seen_by(collection, user, superuser):
     """Test getting viewable permissions as 'user'."""
-    raise NotImplementedError('Fix me for PR #120!')
+    # If there are no permissions, we se no permissions.
+    assert collection.get_permissions_as_seen_by(user) == []
+
+    # If 'user' is not cataloging admin, they don't see regular user permissions on a collection.
+    other_user = UserFactory()
+    others_non_cataloging_admin_permission = Permission(user=other_user, collection=collection,
+                                                        cataloging_admin=False).save_as(superuser)
+    assert others_non_cataloging_admin_permission not in \
+        collection.get_permissions_as_seen_by(user)
+
+    # 'user' sees own and cataloging admin permissions on a collection.
+    users_own_permission = Permission(user=user, collection=collection,
+                                      cataloging_admin=False).save_as(superuser)
+    third_user = UserFactory()
+    thirds_cataloging_admin_permission = Permission(user=third_user, collection=collection,
+                                                    cataloging_admin=True).save_as(superuser)
+    assert len(collection.get_permissions_as_seen_by(user)) == 2
+    assert users_own_permission in collection.get_permissions_as_seen_by(user)
+    assert thirds_cataloging_admin_permission in collection.get_permissions_as_seen_by(user)
+
+    # When 'user' becomes a cataloging admin on a collection, they sees all permissions.
+    users_own_permission.cataloging_admin = True
+    users_own_permission.save()
+    assert len(collection.get_permissions_as_seen_by(user)) == 3
+    assert others_non_cataloging_admin_permission in collection.get_permissions_as_seen_by(user)
+    assert users_own_permission in collection.get_permissions_as_seen_by(user)
+    assert thirds_cataloging_admin_permission in collection.get_permissions_as_seen_by(user)
+
+    # As a system admin, you see all permissions on a collection.
+    assert len(superuser.permissions) == 0
+    assert len(collection.get_permissions_as_seen_by(superuser)) == 3
 
 
 @pytest.mark.usefixtures('db')

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -105,7 +105,7 @@ def test_removing_permissions(superuser, user):
 
 def test_get_permissions_as_seen_by(user):
     """Test getting viewable permissions as 'user'."""
-    raise NotImplementedError('Fix me for PR #109!')
+    raise NotImplementedError('Fix me for PR #120!')
 
 
 @pytest.mark.usefixtures('db')

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -103,6 +103,11 @@ def test_removing_permissions(superuser, user):
     assert permission not in collection.permissions
 
 
+def test_get_permissions_as_seen_by(user):
+    """Test getting viewable permissions as 'user'."""
+    raise NotImplementedError('Fix me for PR #109!')
+
+
 @pytest.mark.usefixtures('db')
 def test_get_replaces_and_replaced_by_str():
     """Check get_replaces_and_replaced_by_str output."""

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -13,7 +13,7 @@ from xl_auth.collection.models import Collection
 from xl_auth.permission.models import Permission
 from xl_auth.user.models import User
 
-from ..factories import CollectionFactory, SuperUserFactory, UserFactory
+from ..factories import CollectionFactory, PermissionFactory, SuperUserFactory, UserFactory
 
 
 def test_get_by_id(superuser):
@@ -136,6 +136,16 @@ def test_get_permissions_as_seen_by(collection, user, superuser):
     # As a system admin, you see all permissions on a collection.
     assert len(superuser.permissions) == 0
     assert len(collection.get_permissions_as_seen_by(superuser)) == 3
+
+
+def test_get_permissions_label_help_text(collection, user, superuser):
+    """Test getting permissions label help text."""
+    assert collection.get_permissions_label_help_text_as_seen_by(superuser) == ''
+    assert (collection.get_permissions_label_help_text_as_seen_by(user) ==
+            _('You will only see all permissions for those collections that you are '
+              'cataloging admin for.'))
+    PermissionFactory(user=user, collection=collection, cataloging_admin=True)
+    assert collection.get_permissions_label_help_text_as_seen_by(user) == ''
 
 
 @pytest.mark.usefixtures('db')

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -171,9 +171,16 @@ def test_is_cataloging_admin(superuser, user):
     assert user.is_cataloging_admin is False
 
 
-def test_is_cataloging_admin_for(collection):
+def test_is_cataloging_admin_for(user, collection, superuser):
     """Test is_cataloging_admin_for return value."""
-    raise NotImplementedError('Fix me for PR #120!')
+    other_collection = CollectionFactory()
+    not_admin_permission = Permission(user=user, collection=collection,
+                                      cataloging_admin=False).save_as(superuser)
+    admin_permission = Permission(user=user, collection=other_collection,
+                                  cataloging_admin=True).save_as(superuser)
+
+    assert user.is_cataloging_admin_for(not_admin_permission.collection) is False
+    assert user.is_cataloging_admin_for(admin_permission.collection) is True
 
 
 def test_has_any_permission_for(collection):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -171,6 +171,16 @@ def test_is_cataloging_admin(superuser, user):
     assert user.is_cataloging_admin is False
 
 
+def test_is_cataloging_admin_for(collection):
+    """Test is_cataloging_admin_for return value."""
+    raise NotImplementedError('Fix me for PR #109!')
+
+
+def test_has_any_permission_for(collection):
+    """Test has_any_permission_for return value."""
+    raise NotImplementedError('Fix me for PR #109!')
+
+
 def test_get_permissions_as_seen_by_self(user):
     """Test getting permissions for self."""
     non_admin_permission = PermissionFactory(user=user, cataloging_admin=False).save_as(user)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -255,7 +255,7 @@ def test_get_permissions_label_help_text(user, superuser):
     PermissionFactory(user=user, cataloging_admin=True).save_as(user)
     assert (superuser.get_permissions_label_help_text_as_seen_by(user) ==
             _('You will only see permissions for those collections that you are '
-              'cataloging administrator for.'))
+              'cataloging admin for.'))
 
 
 @pytest.mark.usefixtures('db')

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -173,12 +173,12 @@ def test_is_cataloging_admin(superuser, user):
 
 def test_is_cataloging_admin_for(collection):
     """Test is_cataloging_admin_for return value."""
-    raise NotImplementedError('Fix me for PR #109!')
+    raise NotImplementedError('Fix me for PR #120!')
 
 
 def test_has_any_permission_for(collection):
     """Test has_any_permission_for return value."""
-    raise NotImplementedError('Fix me for PR #109!')
+    raise NotImplementedError('Fix me for PR #120!')
 
 
 def test_get_permissions_as_seen_by_self(user):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -254,7 +254,7 @@ def test_get_permissions_label_help_text(user, superuser):
     assert superuser.get_permissions_label_help_text_as_seen_by(user) == ''
     PermissionFactory(user=user, cataloging_admin=True).save_as(user)
     assert (superuser.get_permissions_label_help_text_as_seen_by(user) ==
-            _('You will only see all permissions for those collections that you are '
+            _('You will only see permissions for those collections that you are '
               'cataloging administrator for.'))
 
 

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -183,9 +183,15 @@ def test_is_cataloging_admin_for(user, collection, superuser):
     assert user.is_cataloging_admin_for(admin_permission.collection) is True
 
 
-def test_has_any_permission_for(collection):
+def test_has_any_permission_for(user, collection, superuser):
     """Test has_any_permission_for return value."""
-    raise NotImplementedError('Fix me for PR #120!')
+    other_collection = CollectionFactory()
+    regular_permission = Permission(user=user, collection=other_collection,
+                                    cataloging_admin=False).save_as(superuser)
+    assert user.has_any_permission_for(collection) is False
+    regular_permission.collection = collection
+    regular_permission.save()
+    assert user.has_any_permission_for(collection) is True
 
 
 def test_get_permissions_as_seen_by_self(user):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -241,7 +241,7 @@ def test_get_permissions_label_help_text(user, superuser):
     assert superuser.get_permissions_label_help_text_as_seen_by(user) == ''
     PermissionFactory(user=user, cataloging_admin=True).save_as(user)
     assert (superuser.get_permissions_label_help_text_as_seen_by(user) ==
-            _('You will only see permissions for those collections that you are '
+            _('You will only see all permissions for those collections that you are '
               'cataloging administrator for.'))
 
 

--- a/xl_auth/collection/models.py
+++ b/xl_auth/collection/models.py
@@ -41,6 +41,15 @@ class Collection(SurrogatePK, Model):
         """Get by collection code."""
         return Collection.query.filter_by(code=code).first()
 
+    def get_permissions_as_seen_by(self, current_user):
+        """Return subset of permissions viewable by 'current_user'."""
+        if current_user.is_cataloging_admin_for(self) or current_user.is_admin:
+            return self.permissions
+        else:
+            def is_cataloging_admin_or_own_permissions(test_permission):
+                return test_permission.user == current_user or test_permission.cataloging_admin
+            return list(filter(is_cataloging_admin_or_own_permissions, self.permissions))
+
     def get_replaces_and_replaced_by_str(self):
         """Build string with replaces/replaced-by info."""
         if self.replaced_by and self.replaces:

--- a/xl_auth/collection/models.py
+++ b/xl_auth/collection/models.py
@@ -41,6 +41,14 @@ class Collection(SurrogatePK, Model):
         """Get by collection code."""
         return Collection.query.filter_by(code=code).first()
 
+    def get_permissions_label_help_text_as_seen_by(self, current_user):
+        """Return help text for permissions label."""
+        if not (current_user.is_cataloging_admin_for(self) or current_user.is_admin):
+            return _('You will only see all permissions for those collections that you are '
+                     'cataloging admin for.')
+        else:
+            return ''
+
     def get_permissions_as_seen_by(self, current_user):
         """Return subset of permissions viewable by 'current_user'."""
         if current_user.is_cataloging_admin_for(self) or current_user.is_admin:

--- a/xl_auth/commands.py
+++ b/xl_auth/commands.py
@@ -525,7 +525,7 @@ def import_data(verbose, admin_email, wipe_permissions, send_password_resets):
                     permission = Permission.create_as(admin, user=user, collection=collection,
                                                       registrant=True,
                                                       cataloger=collection.code == 'Utb2',
-                                                      cataloging_admin=collection.code == 'Utb2')
+                                                      cataloging_admin=False)
                 else:
                     permission = Permission.create_as(admin, user=user, collection=collection,
                                                       registrant=True, cataloger=True,

--- a/xl_auth/permission/forms.py
+++ b/xl_auth/permission/forms.py
@@ -21,7 +21,7 @@ class PermissionForm(FlaskForm):
                                 validators=[DataRequired()])
     registrant = BooleanField(_('Registrant'))
     cataloger = BooleanField(_('Cataloger'))
-    cataloging_admin = BooleanField(_('Cataloguing Administrator'))
+    cataloging_admin = BooleanField(_('Cataloging Admin'))
 
     def __init__(self, active_user, *args, **kwargs):
         """Create instance."""

--- a/xl_auth/templates/collections/view.html
+++ b/xl_auth/templates/collections/view.html
@@ -68,6 +68,11 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <strong>{{ _('Permissions') }}</strong>
+                {% if collection.get_permissions_label_help_text_as_seen_by(current_user) %}
+                    <span>
+                        ({{ collection.get_permissions_label_help_text_as_seen_by(current_user) }})
+                    </span>
+                {% endif %}
             </div>
             <table class="table table-hover">
                 <thead>

--- a/xl_auth/templates/collections/view.html
+++ b/xl_auth/templates/collections/view.html
@@ -32,62 +32,80 @@
                 {% endif %}
             </dd>
 
-            <dt>{{ _('Last Modified') }}:</dt>
+            <dt>{{ _('Cataloging Admins') }}:</dt>
             <dd>
-                {{ collection.modified_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}, {{  _('by') }}
-                <a href="{{ url_for('user.view', user_id=collection.modified_by.id) }}">
-                    {{ collection.modified_by.full_name }}
-                </a>
+                {% for permission in collection.permissions | selectattr('cataloging_admin')
+                        | sort(attribute='created_at') %}
+                    <a href="{{ url_for('user.view', user_id=permission.user.id) }}">{{
+                        permission.user.email }}</a>{{
+                            _(' and ') if loop.revindex == 2 else (', ' if not loop.last) }}
+                {% else %}
+                    <em>{{ _('None registered, please contact libris@kb.se to create one.') }}</em>
+                {% endfor %}
             </dd>
 
-            <dt>{{ _('Created At') }}:</dt>
-            <dd>
-                {{ collection.created_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}, {{  _('by') }}
-                <a href="{{ url_for('user.view', user_id=collection.created_by.id) }}">
-                    {{ collection.created_by.full_name }}
-                </a>
-            </dd>
+            {% if current_user.is_admin or current_user.is_cataloging_admin %}
+                <dt>{{ _('Last Modified') }}:</dt>
+                <dd>
+                    {{ collection.modified_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}, {{  _('by') }}
+                    <a href="{{ url_for('user.view', user_id=collection.modified_by.id) }}">
+                        {{ collection.modified_by.full_name }}
+                    </a>
+                </dd>
+
+                <dt>{{ _('Created At') }}:</dt>
+                <dd>
+                    {{ collection.created_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}, {{  _('by') }}
+                    <a href="{{ url_for('user.view', user_id=collection.created_by.id) }}">
+                        {{ collection.created_by.full_name }}
+                    </a>
+                </dd>
+            {% endif %}
         </dl>
     </div>
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <strong>{{ _('Permissions') }}</strong>
-        </div>
-        <table class="table table-hover">
-            <thead>
-            <tr>
-                <th class="col-md-2">{{ _('User') }}</th>
-                <th class="col-md-3 word-break-all">{{ _('Registrant') }}</th>
-                <th class="col-md-2 word-break-all">{{ _('Cataloger') }}</th>
-                <th class="col-md-3 word-break-all">{{ _('Cataloguing Administrator') }}</th>
-                <th class="col-md-2">{{ _('Created At') }}</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for permission in collection.permissions | sort(attribute='created_at') %}
+    {% if current_user.is_admin or current_user.is_cataloging_admin
+            or current_user.has_any_permission_for(collection) %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>{{ _('Permissions') }}</strong>
+            </div>
+            <table class="table table-hover">
+                <thead>
                 <tr>
-                    <td class="word-break-all">
-                        <a href="{{ url_for('user.view', user_id=permission.user.id) }}">
-                            {{ permission.user.email }}
-                        </a>
-                    </td>
-                    <td class="{{ "bool-value-{}".format(permission.registrant).lower() }}">
-                        {{ _('Yes') if permission.registrant else _('No') }}
-                    </td>
-                    <td class="{{ "bool-value-{}".format(permission.cataloger).lower() }}">
-                        {{ _('Yes') if permission.cataloger else _('No') }}
-                    </td>
-                    <td class="{{ "bool-value-{}".format(permission.cataloging_admin).lower() }}">
-                        {{ _('Yes') if permission.cataloging_admin else _('No') }}
-                    </td>
-                    <td>{{ permission.created_at.strftime('%y-%m-%d') }}, {{  _('by') }}
-                        <a href="{{ url_for('user.view', user_id=permission.created_by.id) }}">
-                            {{ permission.created_by.full_name }}
-                        </a>
-                    </td>
+                    <th class="col-md-2">{{ _('User') }}</th>
+                    <th class="col-md-3 word-break-all">{{ _('Registrant') }}</th>
+                    <th class="col-md-2 word-break-all">{{ _('Cataloger') }}</th>
+                    <th class="col-md-3 word-break-all">{{ _('Cataloging Admin') }}</th>
+                    <th class="col-md-2">{{ _('Created At') }}</th>
                 </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
+                </thead>
+                <tbody>
+                {% for permission in collection.get_permissions_as_seen_by(current_user)
+                        | sort(attribute='created_at') %}
+                    <tr>
+                        <td class="word-break-all">
+                            <a href="{{ url_for('user.view', user_id=permission.user.id) }}">
+                                {{ permission.user.email }}
+                            </a>
+                        </td>
+                        <td class="{{ "bool-value-{}".format(permission.registrant).lower() }}">
+                            {{ _('Yes') if permission.registrant else _('No') }}
+                        </td>
+                        <td class="{{ "bool-value-{}".format(permission.cataloger).lower() }}">
+                            {{ _('Yes') if permission.cataloger else _('No') }}
+                        </td>
+                        <td class="{{ "bool-value-{}".format(permission.cataloging_admin).lower() }}">
+                            {{ _('Yes') if permission.cataloging_admin else _('No') }}
+                        </td>
+                        <td>{{ permission.created_at.strftime('%y-%m-%d') }}, {{  _('by') }}
+                            <a href="{{ url_for('user.view', user_id=permission.created_by.id) }}">
+                                {{ permission.created_by.full_name }}
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/xl_auth/templates/permissions/home.html
+++ b/xl_auth/templates/permissions/home.html
@@ -17,7 +17,7 @@
                 <th class="col-md-1">{{ _('Collection') }}</th>
                 <th class="col-md-2 word-break-all">{{ _('Registrant') }}</th>
                 <th class="col-md-2 word-break-all">{{ _('Cataloger') }}</th>
-                <th class="col-md-2 word-break-all">{{ _('Cataloguing Administrator') }}</th>
+                <th class="col-md-2 word-break-all">{{ _('Cataloging Admin') }}</th>
                 <th class="col-md-1 min-width-90px">{{ _('Created At') }}</th>
                 <th class="col-md-1"></th>
             </tr>

--- a/xl_auth/templates/public/home.html
+++ b/xl_auth/templates/public/home.html
@@ -7,7 +7,7 @@
                 <div class="col-md-12">
                     <h1>{{ _('Welcome to xl_auth') }}</h1>
                     <p>
-                        {{ _('This is an early beta release of Libris authorization service.') }}
+                        {{ _('This is a beta release of Libris authorization service.') }}
                     </p>
                     <p>
                         {{ _('See email from customer service for instructions.') }}
@@ -24,7 +24,7 @@
                             </h2>
                         </div>
                         <p>
-                            {{ _('This is an early beta release of Libris authorization service.') }}
+                            {{ _('This is a beta release of Libris authorization service.') }}
                         </p>
                         <p>
                             {{ _('See email from customer service for instructions.') }}

--- a/xl_auth/templates/users/inspect.html
+++ b/xl_auth/templates/users/inspect.html
@@ -17,7 +17,7 @@
             <dt>{{ _('System Administrator') }}:</dt>
             <dd>{{ _('Yes') if user.is_admin else _('No') }}</dd>
 
-            <dt>{{ _('Cataloguing Administrator') }}:</dt>
+            <dt>{{ _('Cataloging Admin') }}:</dt>
             <dd>{{ _('Yes') if user.is_cataloging_admin else _('No') }}</dd>
 
             <dt>{{ _('Users Created') }}:</dt>
@@ -71,7 +71,7 @@
                 <th class="col-md-1">{{ _('Collection') }}</th>
                 <th class="col-md-3 word-break-all">{{ _('Registrant') }}</th>
                 <th class="col-md-2 word-break-all">{{ _('Cataloger') }}</th>
-                <th class="col-md-3 word-break-all">{{ _('Cataloguing Administrator') }}</th>
+                <th class="col-md-3 word-break-all">{{ _('Cataloging Admin') }}</th>
                 <th class="col-md-1">{{ _('Active Collection') }}</th>
                 <th class="col-md-2">{{ _('Last Modified') }}</th>
             </tr>

--- a/xl_auth/templates/users/profile.html
+++ b/xl_auth/templates/users/profile.html
@@ -48,10 +48,8 @@
                 <tr>
                     <th>{{ _('Code') }}</th>
                     <th>{{ _('Friendly Name') }}</th>
-                    {% if user.is_admin or user.email == 'test@kb.se' %}
-                        <th>{{ _('Registrant') }}</th>
-                        <th>{{ _('Cataloger') }}</th>
-                    {% endif %}
+                    <th>{{ _('Registrant') }}</th>
+                    <th>{{ _('Cataloger') }}</th>
                     <th>{{ _('Cataloging Admin') }}</th>
                 </tr>
                 </thead>
@@ -65,14 +63,12 @@
                             </a>
                         </td>
                         <td>{{ permission.collection.friendly_name }}</td>
-                        {% if user.is_admin or user.email == 'test@kb.se' %}
-                            <td class="{{ "bool-value-{}".format(permission.registrant).lower() }}">
-                                {{ _('Yes') if permission.registrant else _('No') }}
-                            </td>
-                            <td class="{{ "bool-value-{}".format(permission.cataloger).lower() }}">
-                                {{ _('Yes') if permission.cataloger else _('No') }}
-                            </td>
-                        {% endif %}
+                        <td class="{{ "bool-value-{}".format(permission.registrant).lower() }}">
+                            {{ _('Yes') if permission.registrant else _('No') }}
+                        </td>
+                        <td class="{{ "bool-value-{}".format(permission.cataloger).lower() }}">
+                            {{ _('Yes') if permission.cataloger else _('No') }}
+                        </td>
                         <td class="{{ "bool-value-{}".format(permission.cataloging_admin).lower() }}">
                             {{ _('Yes') if permission.cataloging_admin else _('No') }}
                         </td>

--- a/xl_auth/templates/users/profile.html
+++ b/xl_auth/templates/users/profile.html
@@ -28,7 +28,7 @@
             </div>
             <div class="panel-body">
                 <p>{{ _('If you are missing a permission or any of the permissions below are '
-                        'incorrect, please contact the cataloging administrator for that collection.') }}</p>
+                        'incorrect, please contact the cataloging admin for that collection.') }}</p>
                 <p>{{ _('You can find the collection administrator contact information by following the collection link '
                         'below or by going to <a href="%(collections_link)s">the Collections list view</a> and selecting '
                         'the collection there.', collections_link=url_for('collection.home')) }}</p>

--- a/xl_auth/templates/users/profile.html
+++ b/xl_auth/templates/users/profile.html
@@ -36,7 +36,7 @@ if your permissions are not correctly listed below.') }}</p>
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3>{{ _('Permissions (Active Collections Only)') }}</h3>
-            <p>{{ _('Note: <em>Cataloguing Admin</em> is a new privilege that, in the near future, \
+            <p>{{ _('Note: <em>Cataloging Admin</em> is a new privilege that, in the near future, \
 will allow you to create new user accounts and grant registrant/cataloger privileges to others. ') }}</p>
         </div>
         <div class="panel-body">
@@ -49,7 +49,7 @@ will allow you to create new user accounts and grant registrant/cataloger privil
                         <th>{{ _('Registrant') }}</th>
                         <th>{{ _('Cataloger') }}</th>
                     {% endif %}
-                    <th>{{ _('Cataloguing Administrator') }}</th>
+                    <th>{{ _('Cataloging Admin') }}</th>
                 </tr>
                 </thead>
                 <tbody>

--- a/xl_auth/templates/users/simple_view.html
+++ b/xl_auth/templates/users/simple_view.html
@@ -11,13 +11,15 @@
             <dt>{{ _('Active Account') }}:</dt>
             <dd>{{ _('Yes') if user.is_active else _('No') }}</dd>
 
-            <dt>{{ _('Cataloging admin for') }}:</dt>
+            <dt>{{ _('Cataloging Admin for') }}:</dt>
             <dd>
                 {% for permission in user.get_cataloging_admin_permissions()
                         | sort(attribute='collection.code') %}
                     <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}">
                         {{ permission.collection.code }}
                     </a>
+                {% else %}
+                    -
                 {% endfor %}
             </dd>
         </dl>

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -52,7 +52,7 @@
     <div class="panel panel-default">
         <div class="panel-heading">
             <strong>{{ _('Permissions') }}</strong>
-            {% if user.get_permissions_label_help_text_as_seen_by(current_user) != '' %}
+            {% if user.get_permissions_label_help_text_as_seen_by(current_user) %}
                 <span>({{ user.get_permissions_label_help_text_as_seen_by(current_user) }})</span>
             {% endif %}
         </div>

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -33,7 +33,7 @@
             <dt>{{ _('System Administrator') }}:</dt>
             <dd>{{ _('Yes') if user.is_admin else _('No') }}</dd>
 
-            <dt>{{ _('Cataloguing Administrator') }}:</dt>
+            <dt>{{ _('Cataloging Admin') }}:</dt>
             <dd>{{ _('Yes') if user.is_cataloging_admin else _('No') }}</dd>
 
             <dt>{{ _('Cataloging Admin for') }}:</dt>
@@ -62,7 +62,7 @@
                 <th class="col-md-1">{{ _('Collection') }}</th>
                 <th class="col-md-3 word-break-all">{{ _('Registrant') }}</th>
                 <th class="col-md-2 word-break-all">{{ _('Cataloger') }}</th>
-                <th class="col-md-3 word-break-all">{{ _('Cataloguing Administrator') }}</th>
+                <th class="col-md-3 word-break-all">{{ _('Cataloging Admin') }}</th>
                 <th class="col-md-1">{{ _('Active Collection') }}</th>
                 <th class="col-md-2">{{ _('Last Modified') }}</th>
             </tr>

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -36,13 +36,15 @@
             <dt>{{ _('Cataloguing Administrator') }}:</dt>
             <dd>{{ _('Yes') if user.is_cataloging_admin else _('No') }}</dd>
 
-            <dt>{{ _('Cataloging admin for') }}:</dt>
+            <dt>{{ _('Cataloging Admin for') }}:</dt>
             <dd>
                 {% for permission in user.get_cataloging_admin_permissions()
                         | sort(attribute='collection.code') %}
                     <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}">
                         {{ permission.collection.code }}
                     </a>
+                {% else %}
+                    -
                 {% endfor %}
             </dd>
         </dl>

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -994,7 +994,7 @@ msgid "First Last"
 msgstr "Förnamn Efternamn"
 
 #: xl_auth/templates/users/simple_view.html:14 xl_auth/templates/users/view.html:39
-msgid "Cataloging admin for"
+msgid "Cataloging Admin for"
 msgstr "Ansvarig för"
 
 #: xl_auth/user/forms.py:20

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.2.1\n"
 "Report-Msgid-Bugs-To: mats.blomdahl@gmail.com\n"
-"POT-Creation-Date: 2017-12-07 16:25+0100\n"
+"POT-Creation-Date: 2017-12-11 15:45+0100\n"
 "PO-Revision-Date: 2017-09-19 12:23+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
@@ -69,7 +69,7 @@ msgstr "Kategori"
 msgid "Not a valid choice"
 msgstr "Inte ett giltigt val"
 
-#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:45
+#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:43
 #: xl_auth/collection/views.py:57 xl_auth/collection/views.py:72
 #, python-format
 msgid "Collection code \"%(code)s\" does not exist"
@@ -92,26 +92,35 @@ msgstr "Ny sigel"
 msgid "Code \"%(code)s\" already registered"
 msgstr "Koden \"%(code)s\" är redan registrerad"
 
-#: tests/end2end/test_collection_view.py:28 xl_auth/templates/collections/view.html:4
+#: tests/end2end/test_collection_view.py:26 xl_auth/templates/collections/view.html:4
 #, python-format
 msgid "View Collection '%(code)s'"
 msgstr "Sigel '%(code)s'"
 
-#: tests/end2end/test_collection_view.py:63 tests/end2end/test_collection_view.py:91
-#: tests/end2end/test_permission_deleting.py:25 tests/end2end/test_permission_deleting.py:52
-#: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
-#: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
-#: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
-#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
-#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:65
-#: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
-#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:54
+#: tests/end2end/test_collection_view.py:61 tests/end2end/test_collection_view.py:89
+#: tests/end2end/test_collection_view.py:124 tests/end2end/test_collection_view.py:153
+#: tests/end2end/test_collection_view.py:184 tests/end2end/test_permission_deleting.py:25
+#: tests/end2end/test_permission_deleting.py:52 tests/end2end/test_permission_editing.py:29
+#: tests/end2end/test_permission_editing.py:63 tests/end2end/test_permission_editing.py:90
+#: tests/end2end/test_permission_registering.py:25 tests/end2end/test_permission_registering.py:58
+#: tests/end2end/test_permission_registering.py:85 tests/end2end/test_user_editing.py:197
+#: tests/end2end/test_user_view.py:72 tests/end2end/test_user_view.py:98
+#: xl_auth/templates/collections/view.html:70 xl_auth/templates/nav.html:28
+#: xl_auth/templates/permissions/home.html:4 xl_auth/templates/users/inspect.html:66
+#: xl_auth/templates/users/view.html:54
 msgid "Permissions"
 msgstr "Behörigheter"
 
-#: tests/end2end/test_collection_view.py:125 xl_auth/templates/collections/view.html:35
+#: tests/end2end/test_collection_view.py:123 tests/end2end/test_collection_view.py:152
+#: tests/end2end/test_collection_view.py:181 xl_auth/templates/collections/view.html:35
 msgid "Cataloging Admins"
 msgstr "Administratörer"
+
+#: tests/end2end/test_collection_view.py:125 tests/end2end/test_collection_view.py:154
+#: tests/end2end/test_collection_view.py:185 tests/models/test_collection.py:145
+#: xl_auth/collection/models.py:47
+msgid "You will only see all permissions for those collections that you are cataloging admin for."
+msgstr "Du ser enbart samtliga behörigheter för de sigel du är katalogiseringsadmin för."
 
 #: tests/end2end/test_oauth_deleting_client.py:34 xl_auth/oauth/client/views.py:66
 #, python-format
@@ -213,16 +222,16 @@ msgid "Users"
 msgstr "Användare"
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
-#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:97 xl_auth/templates/collections/view.html:100
+#: xl_auth/templates/collections/view.html:103 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
 #: xl_auth/templates/users/inspect.html:21 xl_auth/templates/users/inspect.html:88
 #: xl_auth/templates/users/inspect.html:91 xl_auth/templates/users/inspect.html:94
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
-#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:70
-#: xl_auth/templates/users/profile.html:73 xl_auth/templates/users/profile.html:77
+#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
+#: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:73
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
@@ -231,16 +240,16 @@ msgid "Yes"
 msgstr "Ja"
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
-#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:97 xl_auth/templates/collections/view.html:100
+#: xl_auth/templates/collections/view.html:103 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
 #: xl_auth/templates/users/inspect.html:21 xl_auth/templates/users/inspect.html:88
 #: xl_auth/templates/users/inspect.html:91 xl_auth/templates/users/inspect.html:94
 #: xl_auth/templates/users/inspect.html:97 xl_auth/templates/users/inspect.html:128
-#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:70
-#: xl_auth/templates/users/profile.html:73 xl_auth/templates/users/profile.html:77
+#: xl_auth/templates/users/inspect.html:162 xl_auth/templates/users/profile.html:67
+#: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:73
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
 #: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
@@ -306,9 +315,9 @@ msgstr "Epost-adressen är redan registrerad"
 msgid "View User '%(email)s'"
 msgstr "Användare '%(email)s'"
 
-#: tests/end2end/test_user_view.py:145 tests/models/test_user.py:234 xl_auth/user/models.py:186
-msgid "You will only see all permissions for those collections that you are cataloging administrator for."
-msgstr "Du kommer enbart se rättigheter knutna till de sigel du är katalogiseringsadministratör för."
+#: tests/end2end/test_user_view.py:145 tests/models/test_user.py:257 xl_auth/user/models.py:198
+msgid "You will only see permissions for those collections that you are cataloging admin for."
+msgstr "Du ser enbart behörigheter på de sigel du är katalogiseringsadmin för."
 
 #: tests/forms/test_client_edit.py:23 tests/forms/test_client_register.py:25
 #: tests/forms/test_collection_edit.py:67 tests/forms/test_collection_register.py:79
@@ -376,17 +385,17 @@ msgstr "Tjänstevillkor redan godkända sedan %(isoformat)s."
 msgid "Field must be between 3 and 255 characters long."
 msgstr "Fältet måste vara mellan 3 och 255 tecken långt."
 
-#: tests/models/test_collection.py:111 xl_auth/collection/models.py:47
+#: tests/models/test_collection.py:156 xl_auth/collection/models.py:64
 #, python-format
 msgid "Replaces %(replaces_code)s, then replaced by %(replaced_by_code)s"
 msgstr "Ersätter %(replaces_code)s, därefter ersatt av sigel %(replaced_by_code)s"
 
-#: tests/models/test_collection.py:114 xl_auth/collection/models.py:50
+#: tests/models/test_collection.py:159 xl_auth/collection/models.py:67
 #, python-format
 msgid "Replaces %(replaces_code)s"
 msgstr "Ersätter sigel %(replaces_code)s"
 
-#: tests/models/test_collection.py:117 xl_auth/collection/models.py:52
+#: tests/models/test_collection.py:162 xl_auth/collection/models.py:69
 #, python-format
 msgid "Replaced by %(replaced_by_code)s"
 msgstr "Ersatt av sigel %(replaced_by_code)s"
@@ -453,7 +462,7 @@ msgstr "OAuth2 Grant token \"%(grant_id)s\" har raderats."
 msgid "Successfully deleted OAuth2 Bearer token \"%(token_id)s\"."
 msgstr "OAuth2 Bearer token \"%(token_id)s\" har raderats."
 
-#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:70
+#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:80
 #: xl_auth/templates/oauth/grants/home.html:14 xl_auth/templates/oauth/tokens/home.html:14
 #: xl_auth/templates/permissions/home.html:16
 msgid "User"
@@ -464,21 +473,21 @@ msgstr "Användare"
 msgid "Collection"
 msgstr "Sigel"
 
-#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:71
+#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:81
 #: xl_auth/templates/permissions/home.html:18 xl_auth/templates/users/inspect.html:72
-#: xl_auth/templates/users/profile.html:52 xl_auth/templates/users/view.html:63
+#: xl_auth/templates/users/profile.html:51 xl_auth/templates/users/view.html:63
 msgid "Registrant"
 msgstr "Beståndsregistrerare"
 
-#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:72
+#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:82
 #: xl_auth/templates/permissions/home.html:19 xl_auth/templates/users/inspect.html:73
-#: xl_auth/templates/users/profile.html:53 xl_auth/templates/users/view.html:64
+#: xl_auth/templates/users/profile.html:52 xl_auth/templates/users/view.html:64
 msgid "Cataloger"
 msgstr "Katalogisatör"
 
-#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:73
+#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:83
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
-#: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:55
+#: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:53
 #: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:65
 msgid "Cataloging Admin"
 msgstr "Katalogiseringsadmin"
@@ -585,7 +594,7 @@ msgid "Friendly Name"
 msgstr "Namn"
 
 #: xl_auth/templates/collections/home.html:25 xl_auth/templates/collections/home.html:76
-#: xl_auth/templates/collections/view.html:54 xl_auth/templates/collections/view.html:74
+#: xl_auth/templates/collections/view.html:56 xl_auth/templates/collections/view.html:84
 #: xl_auth/templates/permissions/home.html:21 xl_auth/templates/users/home.html:22
 #: xl_auth/templates/users/home.html:75 xl_auth/templates/users/inspect.html:55
 #: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:22
@@ -595,7 +604,7 @@ msgstr "Skapad"
 #: xl_auth/templates/collections/home.html:37 xl_auth/templates/collections/home.html:83
 #: xl_auth/templates/collections/view.html:14 xl_auth/templates/collections/view.html:26
 #: xl_auth/templates/users/home.html:32 xl_auth/templates/users/home.html:85
-#: xl_auth/templates/users/profile.html:62
+#: xl_auth/templates/users/profile.html:60
 msgid "View"
 msgstr "Visa"
 
@@ -625,22 +634,22 @@ msgstr "Aktiv"
 msgid "Replaces"
 msgstr "Ersätter"
 
-#: xl_auth/templates/collections/view.html:40
+#: xl_auth/templates/collections/view.html:41
 msgid " and "
 msgstr " och "
 
-#: xl_auth/templates/collections/view.html:42
+#: xl_auth/templates/collections/view.html:43
 msgid "None registered, please contact libris@kb.se to create one."
 msgstr "Ej registrerad, kontakta libris@kb.se för information."
 
-#: xl_auth/templates/collections/view.html:46 xl_auth/templates/users/inspect.html:47
+#: xl_auth/templates/collections/view.html:48 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
 #: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:67
 msgid "Last Modified"
 msgstr "Ändrad"
 
-#: xl_auth/templates/collections/view.html:48 xl_auth/templates/collections/view.html:56
-#: xl_auth/templates/collections/view.html:94 xl_auth/templates/users/inspect.html:49
+#: xl_auth/templates/collections/view.html:50 xl_auth/templates/collections/view.html:58
+#: xl_auth/templates/collections/view.html:105 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
 #: xl_auth/templates/users/view.html:16 xl_auth/templates/users/view.html:24
 #: xl_auth/templates/users/view.html:91
@@ -795,8 +804,8 @@ msgid "Welcome to xl_auth"
 msgstr "Välkommen till Libris Login"
 
 #: xl_auth/templates/public/home.html:10 xl_auth/templates/public/home.html:27
-msgid "This is an early beta release of Libris authorization service."
-msgstr "Det här är en tidig beta-version av Libris inloggningstjänst."
+msgid "This is a beta release of Libris authorization service."
+msgstr "Det här är en beta-version av Libris inloggningstjänst."
 
 #: xl_auth/templates/public/home.html:13 xl_auth/templates/public/home.html:30
 msgid "See email from customer service for instructions."
@@ -980,10 +989,10 @@ msgstr "Viktigt"
 #: xl_auth/templates/users/profile.html:30
 msgid ""
 "If you are missing a permission or any of the permissions below are incorrect, please contact the"
-" cataloging administrator for that collection."
+" cataloging admin for that collection."
 msgstr ""
 "Om du saknar en rättighet eller om någon av rättigheterna nedan är felaktig, vänligen kontakta "
-"katalogiseringsadministratören för aktuellt sigel."
+"katalogiseringsadmin för aktuellt sigel."
 
 #: xl_auth/templates/users/profile.html:32
 #, python-format
@@ -1000,7 +1009,8 @@ msgstr ""
 msgid ""
 "For any other questions or concerns, please contact customer service at <a "
 "href=\"mailto:libris@kb.se\">libris@kb.se</a>."
-msgstr "För övriga frågor, vänligen kontakta Libris kundservice på <a "
+msgstr ""
+"För övriga frågor, vänligen kontakta Libris kundservice på <a "
 "href=\"mailto:libris@kb.se\">libris@kb.se</a>."
 
 #: xl_auth/templates/users/profile.html:43

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.2.1\n"
 "Report-Msgid-Bugs-To: mats.blomdahl@gmail.com\n"
-"POT-Creation-Date: 2017-12-07 14:44+0100\n"
+"POT-Creation-Date: 2017-12-07 15:58+0100\n"
 "PO-Revision-Date: 2017-09-19 12:23+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
@@ -69,7 +69,7 @@ msgstr "Kategori"
 msgid "Not a valid choice"
 msgstr "Inte ett giltigt val"
 
-#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:41
+#: tests/end2end/test_collection_editing.py:146 tests/end2end/test_collection_view.py:45
 #: xl_auth/collection/views.py:57 xl_auth/collection/views.py:72
 #, python-format
 msgid "Collection code \"%(code)s\" does not exist"
@@ -92,10 +92,26 @@ msgstr "Ny sigel"
 msgid "Code \"%(code)s\" already registered"
 msgstr "Koden \"%(code)s\" är redan registrerad"
 
-#: tests/end2end/test_collection_view.py:24 xl_auth/templates/collections/view.html:4
+#: tests/end2end/test_collection_view.py:28 xl_auth/templates/collections/view.html:4
 #, python-format
 msgid "View Collection '%(code)s'"
 msgstr "Sigel '%(code)s'"
+
+#: tests/end2end/test_collection_view.py:63 tests/end2end/test_collection_view.py:91
+#: tests/end2end/test_permission_deleting.py:25 tests/end2end/test_permission_deleting.py:52
+#: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
+#: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
+#: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
+#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
+#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:65
+#: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
+#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:54
+msgid "Permissions"
+msgstr "Behörigheter"
+
+#: tests/end2end/test_collection_view.py:125 xl_auth/templates/collections/view.html:35
+msgid "Cataloging Admins"
+msgstr "Administratörer"
 
 #: tests/end2end/test_oauth_deleting_client.py:34 xl_auth/oauth/client/views.py:66
 #, python-format
@@ -109,17 +125,6 @@ msgstr "Klienter"
 #: tests/end2end/test_oauth_registering_client.py:31 xl_auth/templates/oauth/clients/home.html:11
 msgid "New Client"
 msgstr "Ny klient"
-
-#: tests/end2end/test_permission_deleting.py:25 tests/end2end/test_permission_deleting.py:52
-#: tests/end2end/test_permission_editing.py:29 tests/end2end/test_permission_editing.py:63
-#: tests/end2end/test_permission_editing.py:90 tests/end2end/test_permission_registering.py:25
-#: tests/end2end/test_permission_registering.py:58 tests/end2end/test_permission_registering.py:85
-#: tests/end2end/test_user_editing.py:197 tests/end2end/test_user_view.py:72
-#: tests/end2end/test_user_view.py:98 xl_auth/templates/collections/view.html:54
-#: xl_auth/templates/nav.html:28 xl_auth/templates/permissions/home.html:4
-#: xl_auth/templates/users/inspect.html:66 xl_auth/templates/users/view.html:52
-msgid "Permissions"
-msgstr "Behörigheter"
 
 #: tests/end2end/test_permission_deleting.py:31 xl_auth/templates/permissions/edit.html:7
 msgid "Delete Permission"
@@ -208,8 +213,8 @@ msgid "Users"
 msgstr "Användare"
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:75 xl_auth/templates/collections/view.html:78
-#: xl_auth/templates/collections/view.html:81 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
+#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
@@ -220,14 +225,14 @@ msgstr "Användare"
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
-#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
-#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
+#: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
+#: xl_auth/templates/users/view.html:86 xl_auth/templates/users/view.html:89
 msgid "Yes"
 msgstr "Ja"
 
 #: tests/end2end/test_user_editing.py:52 xl_auth/templates/collections/view.html:9
-#: xl_auth/templates/collections/view.html:75 xl_auth/templates/collections/view.html:78
-#: xl_auth/templates/collections/view.html:81 xl_auth/templates/permissions/home.html:30
+#: xl_auth/templates/collections/view.html:86 xl_auth/templates/collections/view.html:89
+#: xl_auth/templates/collections/view.html:92 xl_auth/templates/permissions/home.html:30
 #: xl_auth/templates/permissions/home.html:31 xl_auth/templates/permissions/home.html:32
 #: xl_auth/templates/users/home.html:38 xl_auth/templates/users/home.html:91
 #: xl_auth/templates/users/inspect.html:15 xl_auth/templates/users/inspect.html:18
@@ -238,8 +243,8 @@ msgstr "Ja"
 #: xl_auth/templates/users/profile.html:70 xl_auth/templates/users/profile.html:74
 #: xl_auth/templates/users/simple_view.html:12 xl_auth/templates/users/view.html:31
 #: xl_auth/templates/users/view.html:34 xl_auth/templates/users/view.html:37
-#: xl_auth/templates/users/view.html:78 xl_auth/templates/users/view.html:81
-#: xl_auth/templates/users/view.html:84 xl_auth/templates/users/view.html:87
+#: xl_auth/templates/users/view.html:80 xl_auth/templates/users/view.html:83
+#: xl_auth/templates/users/view.html:86 xl_auth/templates/users/view.html:89
 msgid "No"
 msgstr "Nej"
 
@@ -448,34 +453,34 @@ msgstr "OAuth2 Grant token \"%(grant_id)s\" har raderats."
 msgid "Successfully deleted OAuth2 Bearer token \"%(token_id)s\"."
 msgstr "OAuth2 Bearer token \"%(token_id)s\" har raderats."
 
-#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:59
+#: xl_auth/permission/forms.py:19 xl_auth/templates/collections/view.html:70
 #: xl_auth/templates/oauth/grants/home.html:14 xl_auth/templates/oauth/tokens/home.html:14
 #: xl_auth/templates/permissions/home.html:16
 msgid "User"
 msgstr "Användare"
 
 #: xl_auth/permission/forms.py:20 xl_auth/templates/permissions/home.html:17
-#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:60
+#: xl_auth/templates/users/inspect.html:71 xl_auth/templates/users/view.html:62
 msgid "Collection"
 msgstr "Sigel"
 
-#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:60
+#: xl_auth/permission/forms.py:22 xl_auth/templates/collections/view.html:71
 #: xl_auth/templates/permissions/home.html:18 xl_auth/templates/users/inspect.html:72
-#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:61
+#: xl_auth/templates/users/profile.html:49 xl_auth/templates/users/view.html:63
 msgid "Registrant"
 msgstr "Beståndsregistrerare"
 
-#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:61
+#: xl_auth/permission/forms.py:23 xl_auth/templates/collections/view.html:72
 #: xl_auth/templates/permissions/home.html:19 xl_auth/templates/users/inspect.html:73
-#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:62
+#: xl_auth/templates/users/profile.html:50 xl_auth/templates/users/view.html:64
 msgid "Cataloger"
 msgstr "Katalogisatör"
 
-#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:62
+#: xl_auth/permission/forms.py:24 xl_auth/templates/collections/view.html:73
 #: xl_auth/templates/permissions/home.html:20 xl_auth/templates/users/inspect.html:20
 #: xl_auth/templates/users/inspect.html:74 xl_auth/templates/users/profile.html:52
-#: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:63
-msgid "Cataloguing Administrator"
+#: xl_auth/templates/users/view.html:36 xl_auth/templates/users/view.html:65
+msgid "Cataloging Admin"
 msgstr "Katalogiseringsadmin"
 
 #: xl_auth/permission/forms.py:78
@@ -580,7 +585,7 @@ msgid "Friendly Name"
 msgstr "Namn"
 
 #: xl_auth/templates/collections/home.html:25 xl_auth/templates/collections/home.html:76
-#: xl_auth/templates/collections/view.html:43 xl_auth/templates/collections/view.html:63
+#: xl_auth/templates/collections/view.html:54 xl_auth/templates/collections/view.html:74
 #: xl_auth/templates/permissions/home.html:21 xl_auth/templates/users/home.html:22
 #: xl_auth/templates/users/home.html:75 xl_auth/templates/users/inspect.html:55
 #: xl_auth/templates/users/inspect.html:120 xl_auth/templates/users/view.html:22
@@ -620,17 +625,25 @@ msgstr "Aktiv"
 msgid "Replaces"
 msgstr "Ersätter"
 
-#: xl_auth/templates/collections/view.html:35 xl_auth/templates/users/inspect.html:47
+#: xl_auth/templates/collections/view.html:40
+msgid " and "
+msgstr " och "
+
+#: xl_auth/templates/collections/view.html:42
+msgid "None registered, please contact libris@kb.se to create one."
+msgstr "Ej registrerad, kontakta libris@kb.se för information."
+
+#: xl_auth/templates/collections/view.html:46 xl_auth/templates/users/inspect.html:47
 #: xl_auth/templates/users/inspect.html:76 xl_auth/templates/users/inspect.html:119
-#: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:65
+#: xl_auth/templates/users/view.html:14 xl_auth/templates/users/view.html:67
 msgid "Last Modified"
 msgstr "Ändrad"
 
-#: xl_auth/templates/collections/view.html:37 xl_auth/templates/collections/view.html:45
-#: xl_auth/templates/collections/view.html:83 xl_auth/templates/users/inspect.html:49
+#: xl_auth/templates/collections/view.html:48 xl_auth/templates/collections/view.html:56
+#: xl_auth/templates/collections/view.html:94 xl_auth/templates/users/inspect.html:49
 #: xl_auth/templates/users/inspect.html:57 xl_auth/templates/users/inspect.html:99
 #: xl_auth/templates/users/view.html:16 xl_auth/templates/users/view.html:24
-#: xl_auth/templates/users/view.html:89
+#: xl_auth/templates/users/view.html:91
 msgid "by"
 msgstr "av"
 
@@ -936,7 +949,7 @@ msgstr "OAuth2-klienter skapade"
 msgid "Clients Modified"
 msgstr "OAuth2-klienter ändrade"
 
-#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:64
+#: xl_auth/templates/users/inspect.html:75 xl_auth/templates/users/view.html:66
 msgid "Active Collection"
 msgstr "Sigel aktivt"
 
@@ -978,7 +991,7 @@ msgstr "Behörigheter på aktiva sigel"
 
 #: xl_auth/templates/users/profile.html:39
 msgid ""
-"Note: <em>Cataloguing Admin</em> is a new privilege that, in the near future, will allow you to "
+"Note: <em>Cataloging Admin</em> is a new privilege that, in the near future, will allow you to "
 "create new user accounts and grant registrant/cataloger privileges to others. "
 msgstr ""
 "Obs: <em>Katalogiseringsadmin</em> är en behörighet som (inom en snar framtid) kommer ge dig "

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -307,7 +307,7 @@ msgid "View User '%(email)s'"
 msgstr "Användare '%(email)s'"
 
 #: tests/end2end/test_user_view.py:145 tests/models/test_user.py:234 xl_auth/user/models.py:186
-msgid "You will only see permissions for those collections that you are cataloging administrator for."
+msgid "You will only see all permissions for those collections that you are cataloging administrator for."
 msgstr "Du kommer enbart se rättigheter knutna till de sigel du är katalogiseringsadministratör för."
 
 #: tests/forms/test_client_edit.py:23 tests/forms/test_client_register.py:25

--- a/xl_auth/user/models.py
+++ b/xl_auth/user/models.py
@@ -195,8 +195,8 @@ class User(UserMixin, SurrogatePK, Model):
         if current_user == self or current_user.is_admin:
             return ''
         elif current_user.is_cataloging_admin:
-            return _('You will only see all permissions for those collections that you are '
-                     'cataloging administrator for.')
+            return _('You will only see permissions for those collections that you are '
+                     'cataloging admin for.')
         else:
             # This text is never shown to regular users viewing another user
             return ''

--- a/xl_auth/user/models.py
+++ b/xl_auth/user/models.py
@@ -195,7 +195,7 @@ class User(UserMixin, SurrogatePK, Model):
         if current_user == self or current_user.is_admin:
             return ''
         elif current_user.is_cataloging_admin:
-            return _('You will only see permissions for those collections that you are '
+            return _('You will only see all permissions for those collections that you are '
                      'cataloging administrator for.')
         else:
             # This text is never shown to regular users viewing another user

--- a/xl_auth/user/models.py
+++ b/xl_auth/user/models.py
@@ -153,6 +153,18 @@ class User(UserMixin, SurrogatePK, Model):
                 return True
         return False
 
+    def is_cataloging_admin_for(self, collection):
+        """Check 'cataloging_admin' status for a specific collection."""
+        for permission in self.permissions:
+            if permission.cataloging_admin and permission.collection == collection:
+                return True
+        return False
+
+    def has_any_permission_for(self, collection):
+        """Check for any permission on a specific collection."""
+        return any([permission for permission in self.permissions
+                    if permission.collection == collection])
+
     def set_password(self, password):
         """Set password."""
         self.password = bcrypt.generate_password_hash(password)


### PR DESCRIPTION
Here is the other batch of fixes for #109 CR remarks.

It's incomplete, unfortunately. Because I got tired and my brain stopped working.. Practically speaking, all the missing features pointed out in #109 are fixed, except for the *"You will only see all permissions for those collections that you are cataloging administrator for."* notice. Unfortunately, since I'm lazy and always looking for shortcuts and "the easy way out", only some of the test coverage updates are in place. 🙀

@mxtthias If you have the time (and the pepp) tomorrow, it would be appreciated if you could add the suitable test codes.. (Marked with "raise NotImplementedError" exceptions.) If not, I'll get to it first thing  Monday morning. Should be done around lunch then.
