### PR TITLE
Prettier rendering of collections list

### DIFF
--- a/xl_auth/templates/users/simple_view.html
+++ b/xl_auth/templates/users/simple_view.html
@@ -15,9 +15,9 @@
             <dd>
                 {% for permission in user.get_cataloging_admin_permissions()
                         | sort(attribute='collection.code') %}
-                    <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}">
-                        {{ permission.collection.code }}
-                    </a>
+                    <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}"
+                    >{{ permission.collection.code }}</a>{{ _(' and ') if loop.revindex == 2
+                        else (', ' if not loop.last) }}
                 {% else %}
                     -
                 {% endfor %}

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -40,9 +40,9 @@
             <dd>
                 {% for permission in user.get_cataloging_admin_permissions()
                         | sort(attribute='collection.code') %}
-                    <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}">
-                        {{ permission.collection.code }}
-                    </a>
+                    <a href="{{ url_for('collection.view', collection_code=permission.collection.code) }}"
+                    >{{ permission.collection.code }}</a>{{ _(' and ') if loop.revindex == 2
+                        else (', ' if not loop.last) }}
                 {% else %}
                     -
                 {% endfor %}


### PR DESCRIPTION
Eftersom kundservice tycker det är vettigt att copy-paste:a detta in i löptext (yey!), så tänkte jag att vi kunde göra dem en tjänst och se till att det blir tydligare vad som är separata länkar:

![screen shot 2017-12-28 at 10 14 56 am](https://user-images.githubusercontent.com/786326/34406332-ad61f1da-ebb8-11e7-9973-e4f9e27924bc.png)

Så blir det nästa gång lite snyggare än såhär i Outlook:

![screen shot 2017-12-28 at 10 20 21 am](https://user-images.githubusercontent.com/786326/34406359-e362539c-ebb8-11e7-9c5e-5c64ff96294a.png)
