### PR TITLE
Disable cataloging admin checkbox for non-superusers

### DIFF
--- a/assets/css/style.less
+++ b/assets/css/style.less
@@ -83,6 +83,10 @@ textarea {
     box-sizing: border-box;
 }
 
+input[disabled]+label {
+    color: #ccc;
+}
+
 /* Table */
 
 tr {

--- a/xl_auth/permission/forms.py
+++ b/xl_auth/permission/forms.py
@@ -60,6 +60,10 @@ class RegisterForm(PermissionForm):
         """Apply 'user_id' and 'collection_id' field defaults."""
         self.user_id.default = user_id
         self.collection_id.default = collection_id
+        if not self.current_user.is_admin:
+            self.cataloging_admin.render_kw = {'disabled': 'disabled',
+                                               'title': _('Cataloging admin rights can only be '
+                                                          'granted by system admins.')}
         self.process()
 
     def validate_collection_id(self, field):
@@ -118,6 +122,10 @@ class EditForm(PermissionForm):
         self.registrant.default = permission.registrant
         self.cataloger.default = permission.cataloger
         self.cataloging_admin.default = permission.cataloging_admin
+        if not self.current_user.is_admin and not permission.cataloging_admin:
+            self.cataloging_admin.render_kw = {'disabled': 'disabled',
+                                               'title': _('Cataloging admin rights can only be '
+                                                          'granted by system admins.')}
         self.process()
 
     # noinspection PyUnusedLocal

--- a/xl_auth/templates/permissions/edit.html
+++ b/xl_auth/templates/permissions/edit.html
@@ -22,18 +22,14 @@
                 {{ edit_permission_form.collection_id(class_="form-control", autocomplete="off") }}
             </div>
             <div class="form-group">
-                <label class="checkbox">
-                    {{ edit_permission_form.registrant() }}
-                    {{ edit_permission_form.registrant.label }}
-                </label>
-                <label class="checkbox">
-                    {{ edit_permission_form.cataloger() }}
-                    {{ edit_permission_form.cataloger.label }}
-                </label>
-                <label class="checkbox">
-                    {{ edit_permission_form.cataloging_admin() }}
-                    {{ edit_permission_form.cataloging_admin.label }}
-                </label>
+                {{ edit_permission_form.registrant() }}
+                {{ edit_permission_form.registrant.label }}
+                <br/>
+                {{ edit_permission_form.cataloger() }}
+                {{ edit_permission_form.cataloger.label }}
+                <br/>
+                {{ edit_permission_form.cataloging_admin() }}
+                {{ edit_permission_form.cataloging_admin.label }}
             </div>
             <p><input class="btn btn-primary btn-submit" type="submit" value="{{ _('Save') }}"></p>
         </form>

--- a/xl_auth/templates/permissions/register.html
+++ b/xl_auth/templates/permissions/register.html
@@ -21,18 +21,14 @@
                 {{ register_permission_form.collection_id(placeholder="ABC", class_="form-control", autocomplete="off") }}
             </div>
             <div class="form-group">
-                <label class="checkbox">
-                    {{ register_permission_form.registrant() }}
-                    {{ register_permission_form.registrant.label }}
-                </label>
-                <label class="checkbox">
-                    {{ register_permission_form.cataloger() }}
-                    {{ register_permission_form.cataloger.label }}
-                </label>
-                <label class="checkbox">
-                    {{ register_permission_form.cataloging_admin() }}
-                    {{ register_permission_form.cataloging_admin.label }}
-                </label>
+                {{ register_permission_form.registrant() }}
+                {{ register_permission_form.registrant.label }}
+                <br/>
+                {{ register_permission_form.cataloger() }}
+                {{ register_permission_form.cataloger.label }}
+                <br/>
+                {{ register_permission_form.cataloging_admin() }}
+                {{ register_permission_form.cataloging_admin.label }}
             </div>
             <p><input class="btn btn-default btn-submit" type="submit" value="{{ _('Register') }}">
             </p>


### PR DESCRIPTION
Only superusers can make someone a cataloging admin, so we disable the
checkbox for everyone else.