### PR TITLE
Feature/Installable, attempt no. 2

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", type: "dhcp", nic_type: "virtio"
+  config.vm.network "private_network", ip: "172.28.128.14"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/ansible/deployment.yml
+++ b/ansible/deployment.yml
@@ -5,8 +5,8 @@
   become: True
   roles:
     - common
-    - docker
     - nginx
     - xl_auth
     - logging
+
 ...

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 
-selinux_enabled: False
+selinux_enabled: True
 
 ...

--- a/ansible/roles/logging/meta/main.yml
+++ b/ansible/roles/logging/meta/main.yml
@@ -16,4 +16,5 @@ galaxy_info:
     - docker
     - logging
 
-dependencies: []
+dependencies:
+  - docker

--- a/ansible/roles/logging/tasks/local-elk-setup.yml
+++ b/ansible/roles/logging/tasks/local-elk-setup.yml
@@ -49,9 +49,11 @@
       - 9200:9200
       - 5044:5044
       - 12201:12201/udp
+  register: elk_docker_started
 
 - name: wait for elasticsearch to be online
-  wait_for: host=localhost port=9200
+  wait_for: host=localhost port=9200 delay=30
+  when: elk_docker_started.changed
 
 - name: wait for elasticsearch health status 'green'
   uri:

--- a/ansible/roles/logging/tasks/local-elk-setup.yml
+++ b/ansible/roles/logging/tasks/local-elk-setup.yml
@@ -53,6 +53,14 @@
 - name: wait for elasticsearch to be online
   wait_for: host=localhost port=9200
 
+- name: wait for elasticsearch health status 'green'
+  uri:
+    url: "http://localhost:9200/_cluster/health"
+    return_content: yes
+  register: elasticsearch_cluster_health
+  until: elasticsearch_cluster_health.json.status == 'green'
+  retries: 30
+
 - name: insert filebeat.template.json
   uri:
     url: "http://localhost:9200/_template/filebeat"

--- a/ansible/roles/nodejs/meta/main.yml
+++ b/ansible/roles/nodejs/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: Mats Blomdahl
+  description: Copied from https://github.com/mblomdahl/jenkins-up/tree/master/roles/nodejs
+  company: National Library of Sweden
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - nodejs
+
+dependencies: []

--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+- name: nodejs 7 repo
+  yum_repository:
+    name: nodesource
+    description: Node.js Packages for Enterprise Linux 7 - $basearch
+    baseurl: https://rpm.nodesource.com/pub_7.x/el/7/$basearch
+    gpgkey: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+  tags: nodejs
+
+- name: install nodejs-7.10.1
+  yum: name=nodejs-7.10.1 state=present
+  tags: nodejs
+
+- name: check if npm version is 5.3.x
+  shell: npm -v
+  register: npm_version
+  changed_when: false
+  tags: nodejs
+
+- name: npm-install npm@5.3 globally
+  npm: name=npm@5.3 global=yes state=present
+  when: not npm_version.stdout.startswith('5.3.')
+  tags: nodejs
+
+- name: install gcc-c++ and make (as per nodejs recommendations)
+  yum: name={{ item }} state=present
+  with_items:
+    - gcc-c++
+    - make
+  tags: nodejs
+
+...

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+postgresql_db: postgres
+postgresql_user: postgres
+postgresql_password: ''
+
+...

--- a/ansible/roles/postgresql/files/pg_hba.conf
+++ b/ansible/roles/postgresql/files/pg_hba.conf
@@ -1,0 +1,19 @@
+# pg_hba.conf for local postgres
+# ----------------------------------
+#
+# NOTE: This conf blindly trusts all connections from localhost. Make sure you
+# take the necessary security precautions.
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+#local   replication     postgres                                peer
+#host    replication     postgres        127.0.0.1/32            ident
+#host    replication     postgres        ::1/128                 ident

--- a/ansible/roles/postgresql/meta/main.yml
+++ b/ansible/roles/postgresql/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: Mats Blomdahl
+  description: PostgreSQL server provisioning.
+  company: National Library of Sweden
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - postgresql
+
+dependencies: []

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+
+- name: install python-psycopg2
+  yum: name=python-psycopg2 state=present
+  tags: postgresql
+
+- name: postgres 9.4 repo
+  yum_repository:
+    name: pgdg94
+    description: PostgreSQL 9.4 $releasever - $basearch
+    baseurl: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-$releasever-$basearch
+  tags: postgresql
+
+- name: install postgresql94-server
+  yum: name=postgresql94-server disable_gpg_check=yes state=present
+  register: postgresql94_server_install
+  tags: postgresql
+
+- name: initialize postgresql database in PGDATA
+  shell: /usr/pgsql-9.4/bin/postgresql94-setup initdb
+  when: postgresql94_server_install.changed
+  tags: postgresql
+
+- name: configure postgresql pg_hba.conf to trust local connections
+  copy:
+    src: pg_hba.conf
+    dest: /var/lib/pgsql/9.4/data/pg_hba.conf
+    owner: postgres
+    group: postgres
+    mode: 0600
+  tags: postgresql
+
+- name: postgresql running and enabled
+  service: name=postgresql-9.4 state=started enabled=yes
+  tags: postgresql
+
+- name: create '{{ postgresql_db }}' postgresql db
+  postgresql_db:
+    login_host: 127.0.0.1
+    port: 5432
+    name: "{{ postgresql_db }}"
+  become: yes
+  become_user: "{{ postgresql_user }}"
+  tags: postgresql
+
+...

--- a/ansible/roles/xl_auth/defaults/main.yml
+++ b/ansible/roles/xl_auth/defaults/main.yml
@@ -4,6 +4,4 @@ xl_auth_admin_pass: ""
 
 xl_auth_docker: "mblomdahl/xl_auth:next"
 
-xl_auth_force_import: ""
-
 ...

--- a/ansible/roles/xl_auth/meta/main.yml
+++ b/ansible/roles/xl_auth/meta/main.yml
@@ -16,4 +16,6 @@ galaxy_info:
     - docker
     - xl_auth
 
-dependencies: []
+dependencies:
+  - docker
+  - nodejs

--- a/ansible/roles/xl_auth/meta/main.yml
+++ b/ansible/roles/xl_auth/meta/main.yml
@@ -17,5 +17,8 @@ galaxy_info:
     - xl_auth
 
 dependencies:
-  - docker
-  - nodejs
+  - role: docker
+  - role: nodejs
+  - role: postgresql
+    postgresql_db: prod
+    postgresql_user: postgres

--- a/ansible/roles/xl_auth/tasks/main.yml
+++ b/ansible/roles/xl_auth/tasks/main.yml
@@ -61,26 +61,6 @@
       OAUTH2_PROVIDER_TOKEN_EXPIRES_IN: 3600
   tags: xl_auth
 
-- name: run 'flask create_user -e libris@kb.se -p <my-secret> --is-active --is-admin --force'
-  docker_container:
-    name: xl_auth_create_user
-    hostname: xl_auth
-    image: "{{ xl_auth_docker }}"
-    recreate: yes
-    interactive: yes
-    tty: yes
-    detach: no
-    command: "create_user -e libris@kb.se -n SuperAdmin -p {{ xl_auth_admin_pass }} --is-active
-             --is-admin --force"
-    log_driver: json-file
-    links:
-      - postgres
-    env:
-      FLASK_DEBUG: 0
-      SQLALCHEMY_DATABASE_URI: postgresql://xl_auth:xl_auth@postgres/prod
-  when: xl_auth_admin_pass | length
-  tags: xl_auth
-
 - name: deploy xl_auth from github
   import_tasks: xl_auth_install.yml
   tags: xl_auth

--- a/ansible/roles/xl_auth/tasks/main.yml
+++ b/ansible/roles/xl_auth/tasks/main.yml
@@ -37,11 +37,11 @@
 - name: start xl_auth
   docker_container:
     name: xl_auth
-    hostname: "{{ inventory_hostname }}"
+    hostname: "{{ xl_auth_server_name }}"
     image: "{{ xl_auth_docker }}"
     pull: yes
     command: prod_run
-    state: started
+    state: stopped
     restart_policy: unless-stopped
     log_driver: gelf
     log_options:
@@ -53,7 +53,7 @@
     ports:
       - 5000:5000
     env:
-      SERVER_NAME: "{{ inventory_hostname }}"
+      SERVER_NAME: "{{ xl_auth_server_name }}"
       XL_AUTH_SECRET: "{{ xl_auth_secret | default('not_secret, as fallback for `vagrant up`') }}"
       PREFERRED_URL_SCHEME: https
       FLASK_DEBUG: 0
@@ -79,6 +79,10 @@
       FLASK_DEBUG: 0
       SQLALCHEMY_DATABASE_URI: postgresql://xl_auth:xl_auth@postgres/prod
   when: xl_auth_admin_pass | length
+  tags: xl_auth
+
+- name: deploy xl_auth from github
+  import_tasks: xl_auth_install.yml
   tags: xl_auth
 
 ...

--- a/ansible/roles/xl_auth/tasks/main.yml
+++ b/ansible/roles/xl_auth/tasks/main.yml
@@ -59,7 +59,6 @@
       FLASK_DEBUG: 0
       SQLALCHEMY_DATABASE_URI: postgresql://xl_auth:xl_auth@postgres/prod
       OAUTH2_PROVIDER_TOKEN_EXPIRES_IN: 3600
-  register: start_xl_auth
   tags: xl_auth
 
 - name: run 'flask create_user -e libris@kb.se -p <my-secret> --is-active --is-admin --force'
@@ -80,31 +79,6 @@
       FLASK_DEBUG: 0
       SQLALCHEMY_DATABASE_URI: postgresql://xl_auth:xl_auth@postgres/prod
   when: xl_auth_admin_pass | length
-  tags: xl_auth
-
-- name: run 'flask import_data'
-  docker_container:
-    name: xl_auth_import_data
-    hostname: xl_auth
-    image: "{{ xl_auth_docker }}"
-    recreate: yes
-    interactive: yes
-    tty: yes
-    detach: no
-    command: "import_data --verbose --admin-email libris@kb.se --wipe-permissions
-             {{ '--send-password-resets' if inventory_hostname == 'login.libris.kb.se' else '' }}"
-    log_driver: syslog
-    log_options:
-      tag: xl_auth_import_data
-    links:
-      - postgres
-    env:
-      SERVER_NAME: "{{ inventory_hostname }}"
-      PREFERRED_URL_SCHEME: https
-      FLASK_DEBUG: 0
-      SQLALCHEMY_DATABASE_URI: postgresql://xl_auth:xl_auth@postgres/prod
-  ignore_errors: yes
-  when: xl_auth_force_import or start_xl_auth.changed
   tags: xl_auth
 
 ...

--- a/ansible/roles/xl_auth/tasks/main.yml
+++ b/ansible/roles/xl_auth/tasks/main.yml
@@ -13,12 +13,12 @@
   when: ssl_key_contents | success
   tags: xl_auth
 
-- name: start postgres
+- name: stop postgres
   docker_container:
     name: postgres
     hostname: postgres
     image: postgres:9.4-alpine
-    state: started
+    state: stopped
     restart_policy: unless-stopped
     log_driver: syslog
     log_options:
@@ -34,7 +34,7 @@
       POSTGRES_PASSWORD: xl_auth
   tags: xl_auth
 
-- name: start xl_auth
+- name: stop xl_auth
   docker_container:
     name: xl_auth
     hostname: "{{ xl_auth_server_name }}"
@@ -57,7 +57,7 @@
       XL_AUTH_SECRET: "{{ xl_auth_secret | default('not_secret, as fallback for `vagrant up`') }}"
       PREFERRED_URL_SCHEME: https
       FLASK_DEBUG: 0
-      SQLALCHEMY_DATABASE_URI: postgresql://xl_auth:xl_auth@postgres/prod
+      SQLALCHEMY_DATABASE_URI: "postgresql://{{ postgresql_user }}:{{ postgresql_password }}@postgres/{{ postgresql_db }}"
       OAUTH2_PROVIDER_TOKEN_EXPIRES_IN: 3600
   tags: xl_auth
 

--- a/ansible/roles/xl_auth/tasks/xl_auth_install.yml
+++ b/ansible/roles/xl_auth/tasks/xl_auth_install.yml
@@ -49,7 +49,7 @@
 
 - name: run 'flask create_user -e libris@kb.se -p <my-secret> --is-active --is-admin --force'
   shell: "sleep 5 && . venv/bin/activate &&
-         SQLALCHEMY_DATABASE_URI=postgresql://xl_auth:xl_auth@localhost/prod
+         SQLALCHEMY_DATABASE_URI=postgresql://{{ postgresql_user }}:{{ postgresql_password }}@127.0.0.1/{{ postgresql_db }}
          FLASK_APP=autoapp.py flask create_user -e libris@kb.se -n SuperAdmin
          -p {{ xl_auth_admin_pass }} --is-active --is-admin --force"
   args:

--- a/ansible/roles/xl_auth/tasks/xl_auth_install.yml
+++ b/ansible/roles/xl_auth/tasks/xl_auth_install.yml
@@ -1,0 +1,58 @@
+---
+
+- name: install virtualenv 15.1.0
+  pip: name=virtualenv version=15.1.0 state=present
+
+- name: checkout xl_auth repo as /opt/xl_auth
+  git:
+    repo: https://github.com/libris/xl_auth.git
+    dest: /opt/xl_auth
+    accept_hostkey: yes
+    force: yes
+  register: xl_auth_git_clone
+
+- name: install xl_auth requirements.txt
+  pip:
+    requirements: /opt/xl_auth/requirements.txt
+    virtualenv: /opt/xl_auth/venv
+
+- name: install npm dependencies and run xl_auth npm build
+  shell: npm install && npm run build && git checkout -- package-lock.json
+  args:
+    chdir: /opt/xl_auth
+  when: xl_auth_git_clone.changed
+
+- name: compile xl_auth translations
+  shell: . venv/bin/activate && FLASK_APP=autoapp.py flask translate -c
+  args:
+    chdir: /opt/xl_auth
+  when: xl_auth_git_clone.changed
+
+- name: create 'xl_auth' user
+  user: name=xl_auth home=/opt/xl_auth shell=/sbin/nologin
+        comment='xl_auth systemd service'
+
+- name: template xl_auth systemd service
+  template:
+    src: xl_auth.service.j2
+    dest: /usr/lib/systemd/system/xl_auth.service
+  register: xl_auth_service
+
+- name: reload systemd daemons
+  systemd: daemon_reload=yes
+  when: xl_auth_service.changed
+
+- name: xl_auth service (re)started and enabled
+  service: name=xl_auth
+           state={{ 're' if xl_auth_service.changed or xl_auth_git_clone.changed else '' }}started
+           enabled=yes
+
+- name: run 'flask create_user -e libris@kb.se -p <my-secret> --is-active --is-admin --force'
+  shell: ". venv/bin/activate && SQLALCHEMY_DATABASE_URI=postgresql://xl_auth:xl_auth@localhost/prod
+         FLASK_APP=autoapp.py flask create_user -e libris@kb.se -n SuperAdmin
+         -p {{ xl_auth_admin_pass }} --is-active --is-admin --force"
+  args:
+    chdir: /opt/xl_auth
+  when: xl_auth_admin_pass | length
+
+...

--- a/ansible/roles/xl_auth/tasks/xl_auth_install.yml
+++ b/ansible/roles/xl_auth/tasks/xl_auth_install.yml
@@ -48,7 +48,8 @@
            enabled=yes
 
 - name: run 'flask create_user -e libris@kb.se -p <my-secret> --is-active --is-admin --force'
-  shell: ". venv/bin/activate && SQLALCHEMY_DATABASE_URI=postgresql://xl_auth:xl_auth@localhost/prod
+  shell: "sleep 5 && . venv/bin/activate &&
+         SQLALCHEMY_DATABASE_URI=postgresql://xl_auth:xl_auth@localhost/prod
          FLASK_APP=autoapp.py flask create_user -e libris@kb.se -n SuperAdmin
          -p {{ xl_auth_admin_pass }} --is-active --is-admin --force"
   args:

--- a/ansible/roles/xl_auth/templates/xl_auth.service.j2
+++ b/ansible/roles/xl_auth/templates/xl_auth.service.j2
@@ -12,7 +12,7 @@ Environment="SERVER_NAME={{ xl_auth_server_name }}"
 Environment="XL_AUTH_SECRET={{ xl_auth_secret | default('not_secret, as fallback for `vagrant up`') }}"
 Environment="PREFERRED_URL_SCHEME=https"
 Environment="FLASK_DEBUG=0"
-Environment="SQLALCHEMY_DATABASE_URI=postgresql://xl_auth:xl_auth@localhost/prod"
+Environment="SQLALCHEMY_DATABASE_URI=postgresql://{{ postgresql_user }}:{{ postgresql_password }}@127.0.0.1/{{ postgresql_db }}"
 Environment="OAUTH2_PROVIDER_TOKEN_EXPIRES_IN=3600"
 ExecStart=/opt/xl_auth/venv/bin/flask prod_run
 TimeoutStopSec=30

--- a/ansible/roles/xl_auth/templates/xl_auth.service.j2
+++ b/ansible/roles/xl_auth/templates/xl_auth.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=xl_auth daemon
+After=syslog.target network.target
+
+[Service]
+User=xl_auth
+Group=xl_auth
+WorkingDirectory=/opt/xl_auth
+Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/xl_auth/venv/bin"
+Environment="FLASK_APP=autoapp.py"
+Environment="SERVER_NAME={{ xl_auth_server_name }}"
+Environment="XL_AUTH_SECRET={{ xl_auth_secret | default('not_secret, as fallback for `vagrant up`') }}"
+Environment="PREFERRED_URL_SCHEME=https"
+Environment="FLASK_DEBUG=0"
+Environment="SQLALCHEMY_DATABASE_URI=postgresql://xl_auth:xl_auth@localhost/prod"
+Environment="OAUTH2_PROVIDER_TOKEN_EXPIRES_IN=3600"
+ExecStart=/opt/xl_auth/venv/bin/flask prod_run
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/xl_auth/vars/main.yml
+++ b/ansible/roles/xl_auth/vars/main.yml
@@ -1,5 +1,8 @@
 ---
 
+xl_auth_server_name: "{{ (inventory_hostname == 'default') | ternary(
+                     ansible_eth1['ipv4']['address'], inventory_hostname) }}"
+
 xl_auth_gelf_address: "{{ (inventory_hostname == 'login.libris.kb.se') | ternary(
                       'udp://log01.kb.se:12201', 'udp://localhost:12201') }}"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xl_auth",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xl_auth",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "author": "National Library of Sweden",
   "license": "Apache-2.0",
   "description": "Authorization and OAuth2 provider for LibrisXL",
@@ -22,7 +22,6 @@
   "keywords": [
     "kb",
     "libris",
-    "bibdb",
     "oauth2"
   ],
   "engines": {

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ factory-boy==2.9.2
 coverage==4.4.1
 flask-shell-ipython==0.3.0
 ansible==2.4.0.0
-lxml==4.0.0
+lxml==4.1.1
 
 # Lint and code style
 flake8==3.4.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -21,7 +21,7 @@ Flask-Migrate==2.1.1
 # Forms (omitting version for WTForms for hacky-technical reasons)
 Flask-WTF==0.14.2
 WTForms
-git+https://github.com/libris/wtforms.git
+WTForms-fork-20180213
 
 # Deployment
 gunicorn==19.7.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,9 +18,10 @@ alembic==0.9.5
 # Migrations
 Flask-Migrate==2.1.1
 
-# Forms
+# Forms (omitting version for WTForms for hacky-technical reasons)
 Flask-WTF==0.14.2
-git+https://github.com/mblomdahl/wtforms.git
+WTForms
+git+https://github.com/libris/wtforms.git
 
 # Deployment
 gunicorn==19.7.1


### PR DESCRIPTION
This pull request attempts to compensate for the failure of #187 by making xl_auth deployable locally— sans-Docker —and in a manner that's similar to how lxlviewer is deployed. #178 should be resolved by transcribing `ansible/roles/xl_auth/tasks/xl_auth_install.yml` into Fabric code and merging it together with libris/devops#18.

Plan is:
- [ ] Replace Docker containers on login.libris.kb.se with local services
- [ ] Re-implement provisioning steps in DevOps Fabric repos