### PR TITLE
Rename OAuth2 scope authorization button

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xl_auth 1.3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-29 13:49+0200\n"
+"POT-Creation-Date: 2018-12-18 15:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -738,20 +738,22 @@ msgid "Delete Permission"
 msgstr ""
 
 #: xl_auth/templates/oauth/authorize.html:5
-msgid "Authorization Request"
+msgid "Share account details"
 msgstr ""
 
 #: xl_auth/templates/oauth/authorize.html:6
 #, python-format
-msgid "OAuth2 client \"%(name)s (%(description)s)\" is requesting access to your account details."
+msgid "%(name)s %(description)s needs access to your account details."
 msgstr ""
 
 #: xl_auth/templates/oauth/authorize.html:8
-msgid "Press \"Authorize\" to approve and get redirected back to the service."
+msgid ""
+"This is necessary for the service to be able to, among other things, display your email and your "
+"permissions."
 msgstr ""
 
 #: xl_auth/templates/oauth/authorize.html:16
-msgid "Authorize"
+msgid "Accept"
 msgstr ""
 
 #: xl_auth/templates/oauth/errors.html:7

--- a/xl_auth/templates/oauth/authorize.html
+++ b/xl_auth/templates/oauth/authorize.html
@@ -2,10 +2,10 @@
 {% extends "layout.html" %}
 {% block content %}
     <div class="container-narrow">
-        <h1>{{ _('Authorization Request') }}</h1>
-        <p class="lead">{{ _('OAuth2 client "%(name)s (%(description)s)" is \
-requesting access to your account details.', name=client.name, description=client.description) }}</p>
-        <p>{{ _('Press "Authorize" to approve and get redirected back to the service.') }}</p>
+        <h1>{{ _('Share account details') }}</h1>
+        <p class="lead">{{ _('%(name)s %(description)s needs access to your account details.',
+            name=client.name, description=client.description) }}
+        {{ _('This is necessary for the service to be able to, among other things, display your email and your permissions.') }}</p>
         <br>
         <div class="row">
             <div class="col-md-12">
@@ -13,7 +13,7 @@ requesting access to your account details.', name=client.name, description=clien
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                     {{ authorize_form.confirm() }}
                     <input class="btn btn-lg btn-primary btn-success" type="submit"
-                           value="{{ _('Authorize') }}">
+                           value="{{ _('Accept') }}">
                 </form>
             </div>
         </div>

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.2.1\n"
 "Report-Msgid-Bugs-To: mats.blomdahl@gmail.com\n"
-"POT-Creation-Date: 2018-08-29 13:49+0200\n"
+"POT-Creation-Date: 2018-12-18 15:20+0100\n"
 "PO-Revision-Date: 2017-09-19 12:23+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
@@ -741,21 +741,23 @@ msgid "Delete Permission"
 msgstr "🙀 Ta bort behörighet"
 
 #: xl_auth/templates/oauth/authorize.html:5
-msgid "Authorization Request"
-msgstr "Auktoriseringsbegäran"
+msgid "Share account details"
+msgstr "Dela uppgifter"
 
 #: xl_auth/templates/oauth/authorize.html:6
 #, python-format
-msgid "OAuth2 client \"%(name)s (%(description)s)\" is requesting access to your account details."
-msgstr "\"%(name)s\" (<em>%(description)s</em>) begär tillgång till dina användaruppgifter."
+msgid "%(name)s %(description)s needs access to your account details."
+msgstr "Om du vill fortsätta behöver %(name)s %(description)s tillgång till dina uppgifter."
 
 #: xl_auth/templates/oauth/authorize.html:8
-msgid "Press \"Authorize\" to approve and get redirected back to the service."
-msgstr "Klicka på \"Auktorisera\" för att godkänna och återvända till tjänsten."
+msgid ""
+"This is necessary for the service to be able to, among other things, display your email and your "
+"permissions."
+msgstr "Detta för att bland annat kunna visa din e-postadress och dina sigel."
 
 #: xl_auth/templates/oauth/authorize.html:16
-msgid "Authorize"
-msgstr "Auktorisera"
+msgid "Accept"
+msgstr "Godkänn"
 
 #: xl_auth/templates/oauth/errors.html:7
 msgid "OAuth Error"


### PR DESCRIPTION
'Authorize'->'Accept', to prevent confusion.