### PR TITLE
Fix broken icons and buttons

### DIFF
--- a/assets/css/style.less
+++ b/assets/css/style.less
@@ -92,6 +92,43 @@ input[disabled]+label {
     color: #ccc;
 }
 
+/* Buttons */
+
+.btn {
+    cursor: pointer;
+    display: inline-block;
+}
+
+.btn-default {
+    background-color: #fff;
+
+    &:hover {
+        background-color: #e6e6e6;
+        border-color: #adadad;
+        color: #333;
+    }
+}
+
+.btn-primary {
+    color: #fff;
+
+    &:hover {
+        background-color: #579095;
+        border-color: #4a7a7f;
+        color: #fff;
+    }
+}
+
+.btn-danger {
+    color: #fff;
+
+    &:hover {
+        background-color: #f75d4c;
+        border-color: #f53e2a;
+        color: #fff;
+    }
+}
+
 /* Table */
 
 tr {

--- a/xl_auth/templates/collections/home.html
+++ b/xl_auth/templates/collections/home.html
@@ -55,7 +55,7 @@
                         <td class="actions">
                             <a class="btn btn-xs btn-default" title="{{ _('Edit') }}"
                                href="{{ url_for('collection.edit', collection_code=collection.code) }}">
-                                <i class="fa fa-pencil"></i>
+                                <i class="fa fa-pencil-alt"></i>
                             </a>
                         </td>
                     {% endif %}
@@ -118,7 +118,7 @@
                         <td class="actions">
                             <a class="btn btn-xs btn-default" title="{{ _('Edit') }}"
                                href="{{ url_for('collection.edit', collection_code=collection.code) }}">
-                                <i class="fa fa-pencil"></i>
+                                <i class="fa fa-pencil-alt"></i>
                             </a>
                         </td>
                     {% endif %}

--- a/xl_auth/templates/collections/view.html
+++ b/xl_auth/templates/collections/view.html
@@ -130,7 +130,7 @@
                                    href="{{ url_for('permission.edit', permission_id=permission.id)
                                             + '?next=' + url_for('collection.view',
                                                                  collection_code=collection.code) }}">
-                                    <i class="fa fa-pencil"></i>
+                                    <i class="fa fa-pencil-alt"></i>
                                 </a>
                                 <a class="btn btn-xs btn-danger"
                                    title="{{ _('Delete Permission') }}"

--- a/xl_auth/templates/nav.html
+++ b/xl_auth/templates/nav.html
@@ -37,7 +37,7 @@
                 </li>
                 <li>
                     <a class="navbar-link" title="{{ _('Log out') }}" href="{{ url_for('public.logout') }}">
-                        <i class="fa fa-sign-out hidden-xs"></i>
+                        <i class="fa fa-sign-out-alt hidden-xs"></i>
                         <span class="hidden-sm">{{ _('Log out') }}</span>
                     </a>
                 </li>

--- a/xl_auth/templates/oauth/clients/home.html
+++ b/xl_auth/templates/oauth/clients/home.html
@@ -29,7 +29,7 @@
                     <td class="actions">
                         <a class="btn btn-xs btn-default" title="{{ _('Edit Client') }}"
                            href="{{ url_for('oauth.client.edit', client_id=client.client_id) }}">
-                            <i class="fa fa-pencil"></i>
+                            <i class="fa fa-pencil-alt"></i>
                         </a>
                         <a class="btn btn-xs btn-danger" title="{{ _('Delete Client') }}"
                            href="{{ url_for('oauth.client.delete', client_id=client.client_id) }}">

--- a/xl_auth/templates/permissions/home.html
+++ b/xl_auth/templates/permissions/home.html
@@ -48,7 +48,7 @@
                         <a class="btn btn-xs btn-default" title="{{ _('Edit') }}"
                            href="{{ url_for('permission.edit', permission_id=permission.id)
                                             + '?next=' + url_for('permission.home') }}">
-                            <i class="fa fa-pencil"></i>
+                            <i class="fa fa-pencil-alt"></i>
                         </a>
                         <a class="btn btn-xs btn-danger" title="{{ _('Delete Permission') }}"
                            href="{{ url_for('permission.delete', permission_id=permission.id)

--- a/xl_auth/templates/users/home.html
+++ b/xl_auth/templates/users/home.html
@@ -56,7 +56,7 @@
                             <a class="btn btn-xs btn-default" title="{{ _('Edit Details') }}"
                                href="{{ url_for('user.administer', user_id=user.id)
                                         + '?next=' + url_for('user.home') }}">
-                                <i class="fa fa-pencil"></i>
+                                <i class="fa fa-pencil-alt"></i>
                             </a>
                             <a class="btn btn-xs btn-default" title="{{ _('Change Password') }}"
                                href="{{ url_for('user.change_password', user_id=user.id)
@@ -119,7 +119,7 @@
                             </a>
                             <a class="btn btn-xs btn-default" title="{{ _('Edit Details') }}"
                                href="{{ url_for('user.administer', user_id=user.id) }}">
-                                <i class="fa fa-pencil"></i>
+                                <i class="fa fa-pencil-alt"></i>
                             </a>
                             <a class="btn btn-xs btn-default" title="{{ _('Change Password') }}"
                                href="{{ url_for('user.change_password', user_id=user.id) }}">

--- a/xl_auth/templates/users/view.html
+++ b/xl_auth/templates/users/view.html
@@ -122,7 +122,7 @@
                             <a class="btn btn-xs btn-default" title="{{ _('Edit') }}"
                                href="{{ url_for('permission.edit', permission_id=permission.id)
                                         + '?next=' + url_for('user.view', user_id=user.id) }}">
-                                <i class="fa fa-pencil"></i>
+                                <i class="fa fa-pencil-alt"></i>
                             </a>
                             <a class="btn btn-xs btn-danger"
                                title="{{ _('Delete Permission') }}"


### PR DESCRIPTION
Previously we used FontAwesome 4.7.0. Upgrading to FontAwesome 5.15.3 broke some icons, because they are no longer in the free version of FontAwesome. Changed them to (subtly) different versions of those icons.

Newer kungbib-styles and/or newer Bootstrap made some buttons look weird. Added some overrides to make it look like before. Might be a nicer way to do this, but it looks like we're on a very old version of kungbib-styles, so doing it "properly" would mean using 2.0 and that's another (bigger) issue, I guess ¯\\\_(ツ)\_/¯