### PR TITLE
Include user id in /verify response

### DIFF
--- a/autoapp.py
+++ b/autoapp.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from flask.helpers import get_debug_flag
+from flask_cors import CORS
 
 from xl_auth.app import create_app
 from xl_auth.settings import DevConfig, ProdConfig
@@ -11,3 +12,4 @@ from xl_auth.settings import DevConfig, ProdConfig
 CONFIG = DevConfig if get_debug_flag() else ProdConfig
 
 app = create_app(CONFIG)
+CORS(app)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "NODE_ENV=production webpack --progress --color --optimization-minimize && flask digest compile",
     "start": "concurrently -n \"WEBPACK,FLASK\" -c \"bgBlue.bold,bgMagenta.bold\" \"npm run webpack-watch\" \"npm run flask-server\"",
     "webpack-watch": "NODE_ENV=debug webpack --mode development --watch",
-    "flask-server": "FLASK_APP=$PWD/autoapp.py FLASK_DEBUG=1 flask run",
+    "flask-server": "FLASK_APP=$PWD/autoapp.py FLASK_DEBUG=1 flask run --port 5001",
     "lint": "eslint \"assets/js/*.js\""
   },
   "repository": {

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,6 +8,7 @@ Jinja2==2.11.3
 itsdangerous==0.24
 click==7.1.2
 sh==1.12.14
+flask-cors==3.0.10
 
 # Database
 Flask-SQLAlchemy==2.5.1

--- a/xl_auth/oauth/views.py
+++ b/xl_auth/oauth/views.py
@@ -160,6 +160,7 @@ def verify():
         user={
             'full_name': oauth.user.full_name,
             'email': oauth.user.email,
+            'id': oauth.user.id,
             'permissions': [{'code': permission.collection.code,
                              'friendly_name': permission.collection.friendly_name,
                              'cataloger': permission.cataloger,


### PR DESCRIPTION
Include user id in /verify response

Plus fixes for local development:
- Allow CORS for all domains using flask-cors (used to be done by nginx)
- Development server on port 5001. So that it doesn't collide with XL dev apache.