### PR TITLE
feat: fix a few security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run the following commands to bootstrap your environment:
     export FLASK_DEBUG=1
     npm run build
     uv run flask db upgrade
-    flask create-user --email me@example.com -p password --is-admin --is-active
+    uv run flask create-user --email me@example.com -p password --is-admin --is-active
     npm start  # run webpack dev server and flask server using concurrently
 
 You will see a pretty welcome screen.

--- a/messages.pot
+++ b/messages.pot
@@ -1,21 +1,21 @@
 # Translations template for xl_auth.
-# Copyright (C) 2023 National Library of Sweden
+# Copyright (C) 2026 National Library of Sweden
 # This file is distributed under the same license as the xl_auth project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: xl_auth 1.10.0\n"
+"Project-Id-Version: xl_auth 1.11.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-07 10:27+0200\n"
+"POT-Creation-Date: 2026-08-05 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.3\n"
 
 #: tests/end2end/test_collection_editing.py:58 tests/end2end/test_collection_registering.py:54
 msgid "category"
@@ -219,49 +219,41 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
-#: tests/end2end/test_public_logging_in.py:142 xl_auth/public/views.py:116
+#: tests/end2end/test_public_logging_in.py:142 xl_auth/public/views.py:124
 msgid "You are logged out."
 msgstr ""
 
-#: tests/end2end/test_public_logging_in.py:156 tests/end2end/test_public_logging_in.py:190
-#: tests/forms/test_public_login.py:43 xl_auth/public/forms.py:39
-msgid "Invalid password"
+#: tests/end2end/test_public_logging_in.py:156 tests/end2end/test_public_logging_in.py:173
+#: tests/end2end/test_public_logging_in.py:190 tests/forms/test_public_login.py:28
+#: xl_auth/public/forms.py:41
+msgid "The username or password you entered is incorrect."
 msgstr ""
 
-#: tests/end2end/test_public_logging_in.py:173 tests/end2end/test_public_reset_password.py:78
-#: tests/forms/test_public_forgot_password.py:19 tests/forms/test_public_login.py:33
-#: xl_auth/public/forms.py:35 xl_auth/public/forms.py:72
-msgid "Unknown username/email"
-msgstr ""
-
-#: tests/end2end/test_public_reset_password.py:28 tests/end2end/test_public_reset_password.py:151
-#: tests/end2end/test_public_reset_password.py:166 xl_auth/templates/public/home.html:47
+#: tests/end2end/test_public_reset_password.py:28 tests/end2end/test_public_reset_password.py:173
+#: tests/end2end/test_public_reset_password.py:188 xl_auth/templates/public/home.html:47
 msgid "Forgot password?"
 msgstr ""
 
-#: tests/end2end/test_public_reset_password.py:99 tests/forms/test_public_reset_password.py:18
-#: xl_auth/public/forms.py:107
+#: tests/end2end/test_public_reset_password.py:67 xl_auth/public/views.py:85
+msgid "If that account exists, a password reset link has been sent to its email address."
+msgstr ""
+
+#: tests/end2end/test_public_reset_password.py:121 tests/forms/test_public_reset_password.py:18
+#: xl_auth/public/forms.py:102
 #, python-format
 msgid "Reset code \"%(code)s\" does not exit"
 msgstr ""
 
-#: tests/end2end/test_public_reset_password.py:117 tests/forms/test_public_reset_password.py:30
-#: xl_auth/public/forms.py:98
+#: tests/end2end/test_public_reset_password.py:139 tests/forms/test_public_reset_password.py:30
+#: xl_auth/public/forms.py:93
 #, python-format
 msgid "Reset code \"%(code)s\" expired at %(isoformat)s"
 msgstr ""
 
-#: tests/end2end/test_public_reset_password.py:141 tests/forms/test_public_reset_password.py:42
-#: xl_auth/public/forms.py:103
+#: tests/end2end/test_public_reset_password.py:163 tests/forms/test_public_reset_password.py:42
+#: xl_auth/public/forms.py:98
 #, python-format
 msgid "Reset code \"%(code)s\" already used (%(isoformat)s)"
-msgstr ""
-
-#: tests/end2end/test_public_reset_password.py:173 tests/forms/test_public_forgot_password.py:46
-#: xl_auth/public/forms.py:65
-msgid ""
-"You already have an active password reset. Please check your email inbox (and your Spam folder) "
-"or try again later."
 msgstr ""
 
 #: tests/end2end/test_user_deletion.py:21 tests/end2end/test_user_editing.py:25
@@ -336,7 +328,7 @@ msgid "Email already registered"
 msgstr ""
 
 #: tests/end2end/test_user_editing.py:192 tests/end2end/test_user_editing.py:216
-#: xl_auth/public/forms.py:52 xl_auth/public/forms.py:80 xl_auth/templates/users/home.html:26
+#: xl_auth/public/forms.py:63 xl_auth/public/forms.py:75 xl_auth/templates/users/home.html:26
 #: xl_auth/templates/users/home.html:100 xl_auth/templates/users/inspect.html:131
 #: xl_auth/templates/users/inspect.html:185 xl_auth/user/forms.py:13
 msgid "Email"
@@ -454,10 +446,6 @@ msgstr ""
 msgid "Collection ID \"%(collection_id)s\" does not exist"
 msgstr ""
 
-#: tests/forms/test_public_login.py:54 xl_auth/public/forms.py:43
-msgid "User not activated"
-msgstr ""
-
 #: tests/forms/test_user_administer.py:30 xl_auth/user/forms.py:108
 msgid "User does not exist"
 msgstr ""
@@ -549,6 +537,18 @@ msgstr ""
 msgid "Thank you for updating client details for \"%(client_id)s\"."
 msgstr ""
 
+#: xl_auth/oauth/grant/models.py:64 xl_auth/oauth/token/models.py:77
+#: xl_auth/templates/oauth/grants/home.html:15 xl_auth/templates/oauth/tokens/home.html:15
+#: xl_auth/templates/users/inspect.html:258
+msgid "Client"
+msgstr ""
+
+#: xl_auth/oauth/grant/models.py:64 xl_auth/oauth/token/models.py:77
+#: xl_auth/templates/oauth/grants/home.html:16 xl_auth/templates/oauth/tokens/home.html:16
+#: xl_auth/templates/users/inspect.html:229 xl_auth/templates/users/inspect.html:261
+msgid "Expires At"
+msgstr ""
+
 #: xl_auth/oauth/grant/views.py:39
 #, python-format
 msgid "Successfully deleted OAuth2 Grant token \"%(grant_id)s\"."
@@ -590,21 +590,21 @@ msgstr ""
 msgid "--- Select Collection ---"
 msgstr ""
 
-#: xl_auth/public/forms.py:18 xl_auth/templates/public/home.html:41
+#: xl_auth/public/forms.py:23 xl_auth/templates/public/home.html:41
 msgid "Username"
 msgstr ""
 
-#: xl_auth/public/forms.py:19 xl_auth/public/forms.py:81 xl_auth/templates/public/home.html:43
+#: xl_auth/public/forms.py:24 xl_auth/public/forms.py:76 xl_auth/templates/public/home.html:43
 #: xl_auth/templates/public/reset_password.html:16 xl_auth/templates/users/change_password.html:16
 #: xl_auth/user/forms.py:168
 msgid "Password"
 msgstr ""
 
-#: xl_auth/public/forms.py:82 xl_auth/user/forms.py:169
+#: xl_auth/public/forms.py:77 xl_auth/user/forms.py:169
 msgid "Verify password"
 msgstr ""
 
-#: xl_auth/public/forms.py:84 xl_auth/user/forms.py:170
+#: xl_auth/public/forms.py:79 xl_auth/user/forms.py:170
 msgid "Passwords must match"
 msgstr ""
 
@@ -612,12 +612,7 @@ msgstr ""
 msgid "You are logged in."
 msgstr ""
 
-#: xl_auth/public/views.py:78
-#, python-format
-msgid "Password reset link sent to %(email)s."
-msgstr ""
-
-#: xl_auth/public/views.py:100
+#: xl_auth/public/views.py:108
 #, python-format
 msgid "Password for \"%(username)s\" has been reset."
 msgstr ""
@@ -863,16 +858,6 @@ msgstr ""
 #: xl_auth/templates/oauth/grants/home.html:13 xl_auth/templates/oauth/tokens/home.html:13
 #: xl_auth/templates/users/inspect.html:256
 msgid "ID"
-msgstr ""
-
-#: xl_auth/templates/oauth/grants/home.html:15 xl_auth/templates/oauth/tokens/home.html:15
-#: xl_auth/templates/users/inspect.html:258
-msgid "Client"
-msgstr ""
-
-#: xl_auth/templates/oauth/grants/home.html:16 xl_auth/templates/oauth/tokens/home.html:16
-#: xl_auth/templates/users/inspect.html:229 xl_auth/templates/users/inspect.html:261
-msgid "Expires At"
 msgstr ""
 
 #: xl_auth/templates/oauth/grants/home.html:28

--- a/tests/end2end/test_oauth_client_flow.py
+++ b/tests/end2end/test_oauth_client_flow.py
@@ -10,7 +10,7 @@ from xl_auth import __version__
 from xl_auth.oauth.grant.models import Grant
 from xl_auth.oauth.token.models import Token
 
-from ..factories import CollectionFactory, PermissionFactory
+from ..factories import ClientFactory, CollectionFactory, PermissionFactory
 
 
 def test_oauth_authorize_success(user, client, testapp):
@@ -40,6 +40,77 @@ def test_oauth_authorize_success(user, client, testapp):
     assert grant is not None
     assert res.status_code == 308
     assert res.location == client.default_redirect_uri + '/?code={}'.format(grant.code)
+
+
+def _login(res, user):
+    """Follow the redirect to the login page, then fill out and submit the login form."""
+    # An unauthenticated /oauth/authorize GET returns a 302 to the login page.
+    res = res.follow()
+    login_form = res.forms['loginForm']
+    login_form['username'] = user.email
+    login_form['password'] = 'myPrecious'
+    return login_form.submit().follow()
+
+
+def test_reauthorizing_same_client_and_scopes_skips_consent(user, client, testapp):
+    """Once a client is authorized, the same client+scopes is not prompted again."""
+    authorize_params = {'client_id': client.client_id, 'response_type': 'code',
+                        'redirect_uri': client.default_redirect_uri,
+                        'scope': ' '.join(client.default_scopes)}
+    # First authorization: log in, see consent form, confirm. Confirming redirects to
+    # the client's redirect_uri with the grant code.
+    res = _login(testapp.get('/oauth/authorize', params=authorize_params), user)
+    assert 'authorizeForm' in res.forms
+    res = res.forms['authorizeForm'].submit()
+    assert res.status_code in (302, 308)
+    assert res.location.startswith(client.default_redirect_uri) and 'code=' in res.location
+
+    # Second authorization for the *same* client and scopes: no consent form is shown,
+    # the grant is issued directly (redirect straight to the client with a code).
+    res = testapp.get('/oauth/authorize', params=authorize_params)
+    assert res.status_code in (302, 308)
+    assert res.location.startswith(client.default_redirect_uri) and 'code=' in res.location
+
+
+def test_authorizing_one_client_does_not_authorize_another(user, client, testapp):
+    """A prior consent must not silently approve a different client (enumeration/phishing)."""
+    other_client = ClientFactory()
+    other_client.save()
+
+    # Authorize the first client fully.
+    res = _login(testapp.get('/oauth/authorize',
+                             params={'client_id': client.client_id, 'response_type': 'code',
+                                     'redirect_uri': client.default_redirect_uri,
+                                     'scope': ' '.join(client.default_scopes)}), user)
+    res.forms['authorizeForm'].submit().follow()
+
+    # Now a *different* client must still get the consent screen, not an auto-grant.
+    res = testapp.get('/oauth/authorize',
+                      params={'client_id': other_client.client_id, 'response_type': 'code',
+                              'redirect_uri': other_client.default_redirect_uri,
+                              'scope': ' '.join(other_client.default_scopes)})
+    assert 'authorizeForm' in res.forms
+    # And no grant exists for the other client until the user actually confirms.
+    assert Grant.query.filter_by(client_id=other_client.client_id).first() is None
+
+
+def test_authorizing_narrow_scope_does_not_authorize_broader(user, testapp):
+    """Consent for a subset of scopes must not auto-approve a request for more scopes."""
+    client = ClientFactory(default_scopes='read write')
+    client.save()
+    redirect_uri = client.default_redirect_uri
+
+    # Authorize for 'read' only.
+    res = _login(testapp.get('/oauth/authorize',
+                             params={'client_id': client.client_id, 'response_type': 'code',
+                                     'redirect_uri': redirect_uri, 'scope': 'read'}), user)
+    res.forms['authorizeForm'].submit().follow()
+
+    # Requesting the broader 'read write' still prompts.
+    res = testapp.get('/oauth/authorize',
+                      params={'client_id': client.client_id, 'response_type': 'code',
+                              'redirect_uri': redirect_uri, 'scope': 'read write'})
+    assert 'authorizeForm' in res.forms
 
 
 def test_oauth_authorize_missing_client_id(user, testapp):

--- a/tests/end2end/test_public_logging_in.py
+++ b/tests/end2end/test_public_logging_in.py
@@ -152,8 +152,8 @@ def test_sees_error_message_if_password_is_incorrect(user, testapp):
     form['password'] = 'wrong'
     # Submits.
     res = form.submit()
-    # Sees error.
-    assert _('Invalid password') in res
+    # Sees the generic error (does not reveal the password was the wrong part).
+    assert _('The username or password you entered is incorrect.') in res
     # Also traceable in Nginx logs:
     assert res.headers['X-Username'] == user.email
 
@@ -169,8 +169,8 @@ def test_sees_error_message_if_username_doesnt_exist(user, testapp):
     form['password'] = 'myPrecious'
     # Submits.
     res = form.submit()
-    # Sees error.
-    assert _('Unknown username/email') in res
+    # Sees the same generic error as a wrong password (no account enumeration).
+    assert _('The username or password you entered is incorrect.') in res
     # Also traceable in Nginx logs:
     assert res.headers['X-Username'] == 'unknown@example.com'
 
@@ -186,8 +186,8 @@ def test_block_login_on_too_many_failed_attempts(user, testapp):
     form['password'] = 'wrong'
     # Submits.
     res = form.submit()
-    # Sees error.
-    assert _('Invalid password') in res
+    # Sees the generic error.
+    assert _('The username or password you entered is incorrect.') in res
 
     # Goes to homepage a second time.
     res = testapp.get('/')

--- a/tests/end2end/test_public_reset_password.py
+++ b/tests/end2end/test_public_reset_password.py
@@ -64,22 +64,50 @@ def test_can_complete_password_reset_flow(db, testapp):
     assert updated_password_reset.user.modified_by == updated_password_reset.user
 
 
+def _generic_forgot_message():
+    """The locale-resolved generic forgot-password message.
+
+    Evaluated on call (inside the app context) rather than at import time, so it
+    resolves to the active locale and matches what the view actually flashes.
+    """
+    return _('If that account exists, a password reset link has been sent to '
+             'its email address.')
+
+
 # noinspection PyUnusedLocal
-def test_sees_error_message_if_username_does_not_exist(user, testapp):
-    """Show error if username doesn't exist."""
+def test_unknown_username_shows_generic_message(user, testapp):
+    """An unknown email shows the same generic message and creates no reset."""
     # Goes to 'Forgot Password?' page.
     res = testapp.get(url_for('public.forgot_password'))
-    # Fills out ForgotPasswordForm.
+    # Fills out ForgotPasswordForm with an address that has no account.
     form = res.forms['forgotPasswordForm']
     form['username'] = 'unknown@example.com'
     # Submits.
-    res = form.submit()
-    # Sees error.
-    assert _('Unknown username/email') in res
+    res = form.submit().follow()
+    # Sees the generic, non-enumerating message.
+    assert escape(_generic_forgot_message()) in res
 
     # No PasswordReset is added.
-    password_reset = PasswordReset.query.filter_by(user=user).first()
-    assert password_reset is None
+    assert PasswordReset.query.count() == 0
+
+
+def test_known_and_unknown_usernames_are_indistinguishable(user, testapp):
+    """A known and an unknown email produce the same visible response body."""
+    def submit(email):
+        res = testapp.get(url_for('public.forgot_password'))
+        form = res.forms['forgotPasswordForm']
+        form['username'] = email
+        return res.forms['forgotPasswordForm'].submit().follow()
+
+    known_res = submit(user.email)
+    unknown_res = submit('definitely-not-a-user@example.com')
+
+    # Same generic message shown in both cases ...
+    assert escape(_generic_forgot_message()) in known_res
+    assert escape(_generic_forgot_message()) in unknown_res
+    # ... and only the real account got a reset created.
+    assert PasswordReset.query.count() == 1
+    assert PasswordReset.query.first().user == user
 
 
 # noinspection PyUnusedLocal
@@ -141,8 +169,8 @@ def test_sees_error_message_if_attempting_to_use_reset_code_twice(password_reset
                     isoformat=password_reset.modified_at.isoformat() + 'Z')) in res
 
 
-def test_sees_error_message_if_too_many_active_password_resets(user, testapp):
-    """Show error if too many active password resets exist."""
+def test_too_many_active_password_resets_shows_generic_message(user, testapp):
+    """Hitting the active-reset limit shows the generic message and creates no new reset."""
     # Create active password resets
     for _i in range(0, current_app.config['XL_AUTH_MAX_ACTIVE_PASSWORD_RESETS']):
         # Goes to homepage.
@@ -168,7 +196,10 @@ def test_sees_error_message_if_too_many_active_password_resets(user, testapp):
     form = res.forms['forgotPasswordForm']
     form['username'] = user.email
     # Submits.
-    res = form.submit()
+    res = form.submit().follow()
     assert res.status_code == 200
-    assert _('You already have an active password reset. Please check your email inbox (and your '
-             'Spam folder) or try again later.') in res
+    # Same generic message as always -- the limit is not disclosed to the requester.
+    assert escape(_generic_forgot_message()) in res
+    # And no additional reset was created beyond the limit.
+    assert len(user.get_active_and_recent_password_resets()) == \
+        current_app.config['XL_AUTH_MAX_ACTIVE_PASSWORD_RESETS']

--- a/tests/forms/test_public_forgot_password.py
+++ b/tests/forms/test_public_forgot_password.py
@@ -1,22 +1,20 @@
 """Test public ForgotPasswordForm."""
 
 
-from datetime import datetime, timedelta
-
-from flask_babel import gettext as _
-
 from xl_auth.public.forms import ForgotPasswordForm
-
-from ..factories import PasswordResetFactory
 
 
 # noinspection PyUnusedLocal
 def test_validate_unknown_username(db):
-    """Unknown username."""
+    """Unknown username still validates at the form level.
+
+    The form doesn't reveal whether an account exists; that decision (and the
+    active-reset limit) is enforced in ``public.views.forgot_password``, which always
+    returns the same generic response.
+    """
     form = ForgotPasswordForm(username='unknown@example.com')
 
-    assert form.validate() is False
-    assert _('Unknown username/email') in form.username.errors
+    assert form.validate() is True
 
 
 def test_validate_success(user):
@@ -26,22 +24,9 @@ def test_validate_success(user):
     assert form.validate() is True
 
 
-def test_validate_too_many_recent_active_resets(app, user):
-    """Too many recent active resets."""
-    old_active_reset = PasswordResetFactory(user=user)
-    old_active_reset.created_at = datetime.utcnow() - timedelta(hours=3)
-    PasswordResetFactory(user=user)
+# noinspection PyUnusedLocal
+def test_validate_requires_username(db):
+    """An empty username fails basic field validation."""
+    form = ForgotPasswordForm(username='')
 
-    form = ForgotPasswordForm(username=user.email)
-
-    # One active but old and one active and recent are fine
-    assert form.validate() is True
-
-    PasswordResetFactory(user=user)
-
-    form = ForgotPasswordForm(username=user.email)
-
-    # Two active and recent are not fine
     assert form.validate() is False
-    assert _('You already have an active password reset. Please check your email inbox (and your '
-             'Spam folder) or try again later.') in form.username.errors

--- a/tests/forms/test_public_login.py
+++ b/tests/forms/test_public_login.py
@@ -25,30 +25,44 @@ def test_validate_success_with_different_username_casing(user):
     assert form.user == user
 
 
+def _assert_generic_login_error(form):
+    """The failure has a single generic message, form-level (not on a field).
+
+    Form-level means ``flash_errors`` won't prefix it with a field label, and it
+    doesn't disclose which of username/password was wrong.
+    """
+    generic_error = _('The username or password you entered is incorrect.')
+    assert generic_error in form.form_errors
+    assert generic_error not in form.username.errors
+    assert generic_error not in form.password.errors
+
+
 # noinspection PyUnusedLocal
 def test_validate_unknown_username(db):
-    """Unknown username."""
+    """Unknown username yields the generic error (no account enumeration)."""
     form = LoginForm(username='unknown@example.com', password='example')
     assert form.validate() is False
-    assert _('Unknown username/email') in form.username.errors
+    _assert_generic_login_error(form)
     assert form.user is None
 
 
 def test_validate_invalid_password(user):
-    """Invalid password."""
+    """Invalid password yields the generic error (indistinguishable from unknown user)."""
     user.set_password('example')
     user.save()
     form = LoginForm(username=user.email, password='wrongPassword')
     assert form.validate() is False
-    assert _('Invalid password') in form.password.errors
+    _assert_generic_login_error(form)
 
 
 def test_validate_inactive_user(user):
-    """Inactive user."""
+    """Inactive user yields the generic error (does not reveal the account exists)."""
     user.is_active = False
     user.set_password('example')
     user.save()
     # Correct username and password, but user is not activated.
     form = LoginForm(username=user.email, password='example')
     assert form.validate() is False
-    assert _('User not activated') in form.username.errors
+    _assert_generic_login_error(form)
+    # The account's existence must not leak via ``form.user`` either.
+    assert form.user is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,27 @@
 """Test configs."""
 
 
+import pytest
+
 from xl_auth.app import create_app
 from xl_auth.settings import DevConfig, ProdConfig
 
 
-def test_production_config():
+def test_production_config(monkeypatch):
     """Production config."""
+    monkeypatch.setenv('XL_AUTH_SECRET', 'a-real-secret')
     app = create_app(ProdConfig)
     assert app.config['ENV'] == 'prod'
     assert app.config['DEBUG'] is False
     assert app.config['DEBUG_TB_ENABLED'] is False
+    assert app.config['SECRET_KEY'] == 'a-real-secret'
+
+
+def test_production_config_refuses_default_secret(monkeypatch):
+    """Production refuses to start without an explicit secret."""
+    monkeypatch.delenv('XL_AUTH_SECRET', raising=False)
+    with pytest.raises(RuntimeError, match='XL_AUTH_SECRET must be set'):
+        create_app(ProdConfig)
 
 
 def test_dev_config():

--- a/xl_auth/app.py
+++ b/xl_auth/app.py
@@ -1,13 +1,15 @@
 """The app module, containing the app factory function."""
 
 
+import os
+
 from flask import Flask, render_template, request
 from flask_login import current_user
 
 from . import collection, commands, oauth, permission, public, user
 from .extensions import (babel, bcrypt, cache, csrf_protect, db, debug_toolbar, login_manager,
                          migrate, oauth_provider, flask_static_digest)
-from .settings import ProdConfig
+from .settings import DEFAULT_SECRET_KEY, ProdConfig
 
 
 def create_app(config_object=ProdConfig):
@@ -17,6 +19,12 @@ def create_app(config_object=ProdConfig):
     """
     app = Flask(__name__.split('.')[0])
     app.config.from_object(config_object)
+    if not app.debug and not app.testing:
+        secret = os.environ.get('XL_AUTH_SECRET')
+        if not secret or secret == DEFAULT_SECRET_KEY:
+            raise RuntimeError('XL_AUTH_SECRET must be set to a non-default value in '
+                               'production; refusing to start with the default secret key.')
+        app.config['SECRET_KEY'] = secret
     app.json.ensure_ascii = False
     register_extensions(app)
     register_blueprints(app)

--- a/xl_auth/oauth/views.py
+++ b/xl_auth/oauth/views.py
@@ -113,6 +113,20 @@ def require_oauth_invalid(req):
     return jsonify(app_version=current_app.config['APP_VERSION'], message=req.error_message), 401
 
 
+def _already_authorized(client_id, scopes):
+    """Whether `client_id` was already granted (at least) `scopes` this session."""
+    authorized = session.get('authorized_scopes', {})
+    return set(scopes).issubset(set(authorized.get(client_id, [])))
+
+
+def _remember_authorization(client_id, scopes):
+    """Record in-session consent for `client_id` covering (at least) `scopes`."""
+    authorized = session.get('authorized_scopes', {})
+    previously = set(authorized.get(client_id, []))
+    authorized[client_id] = sorted(previously | set(scopes))
+    session['authorized_scopes'] = authorized
+
+
 @blueprint.route('/authorize', methods=['GET', 'POST'])
 @login_required
 @oauth_provider.authorize_handler
@@ -123,16 +137,18 @@ def authorize(*_, **kwargs):
         client_id = kwargs.get('client_id')
         client = Client.query.filter_by(client_id=client_id).first()
         kwargs['client'] = client
-        has_authorized_scopes = session.get('has_authorized_scopes', False)
-        if has_authorized_scopes:
+        # Skip the consent screen only when this specific client has already been
+        # authorized for (at least) the requested scopes this session.
+        if _already_authorized(client_id, kwargs.get('scopes') or []):
             return True
         else:
             return render_template('oauth/authorize.html', authorize_form=authorize_form, **kwargs)
 
     confirm = authorize_form['confirm'].data == 'y'
     if confirm:
-        # TODO https://jira.kb.se/browse/LXL-1319
-        session['has_authorized_scopes'] = True
+        client_id = request.values.get('client_id')
+        scopes = (request.values.get('scope') or '').split()
+        _remember_authorization(client_id, scopes)
     return confirm
 
 

--- a/xl_auth/public/forms.py
+++ b/xl_auth/public/forms.py
@@ -3,13 +3,15 @@
 
 from datetime import datetime
 
-from flask import current_app
 from flask_babel import lazy_gettext as _
 from flask_wtf import FlaskForm
 from wtforms import HiddenField, PasswordField, StringField
 from wtforms.validators import DataRequired, EqualTo, Length
 
+from ..extensions import bcrypt
 from ..user.models import PasswordReset, User
+
+_TIMING_EQUALIZER_HASH = bcrypt.generate_password_hash('timing-equalizer')
 
 
 class LoginForm(FlaskForm):
@@ -30,17 +32,21 @@ class LoginForm(FlaskForm):
         if not initial_validation:
             return False
 
+        # Generic message for each kind of failure (unknown user, invalid password,
+        # inactive/deleted account) to prevent user enumeration.
+        generic_error = _('The username or password you entered is incorrect.')
+
         self.user = User.get_by_email(self.username.data)
-        if (not self.user) or self.user.is_deleted:
-            self.username.errors.append(_('Unknown username/email'))
+        if (not self.user) or self.user.is_deleted or not self.user.is_active:
+            # Do a bcrypt comparison so that this path "costs" the same as the one for
+            # valid users, because skipping the hash check would be a timing oracle.
+            bcrypt.check_password_hash(_TIMING_EQUALIZER_HASH, self.password.data)
+            self.form_errors.append(generic_error)
+            self.user = None
             return False
 
         if not self.user.check_password(self.password.data):
-            self.password.errors.append(_('Invalid password'))
-            return False
-
-        if not self.user.is_active:
-            self.username.errors.append(_('User not activated'))
+            self.form_errors.append(generic_error)
             return False
 
         return True
@@ -51,27 +57,8 @@ class ForgotPasswordForm(FlaskForm):
 
     username = StringField(_('Email'), validators=[DataRequired()])
 
-    def validate(self, extra_validators=None):
-        """Validate the form."""
-        initial_validation = super(ForgotPasswordForm, self).validate(extra_validators)
-
-        if not initial_validation:
-            return False
-
-        user = User.get_by_email(self.username.data)
-        if user:
-            active_resets = user.get_active_and_recent_password_resets()
-            if len(active_resets) >= current_app.config['XL_AUTH_MAX_ACTIVE_PASSWORD_RESETS']:
-                self.username.errors.append(_('You already have an active password reset. Please '
-                                              'check your email inbox (and your Spam folder) or '
-                                              'try again later.'))
-                return False
-            else:
-                return True
-        else:
-            self.username.errors.append(_('Unknown username/email'))
-            return False
-
+    # To prevent user enumeration we *don't* check for account existence or
+    # reset limit here.
 
 class ResetPasswordForm(FlaskForm):
     """Reset password form."""

--- a/xl_auth/public/views.py
+++ b/xl_auth/public/views.py
@@ -117,7 +117,7 @@ def reset_password(email, code):
 @login_required
 def logout():
     """Logout."""
-    session.pop('has_authorized_scopes', None)
+    session.pop('authorized_scopes', None)
     logout_user()
     flash(_('You are logged out.'), 'info')
     return redirect(url_for('public.home'))

--- a/xl_auth/public/views.py
+++ b/xl_auth/public/views.py
@@ -71,11 +71,17 @@ def forgot_password():
     forgot_password_form = ForgotPasswordForm(request.form)
     if request.method == 'POST':
         if forgot_password_form.validate_on_submit():
+            # Always the same response, to prevent user enumeration.
             user = User.get_by_email(forgot_password_form.username.data)
-            password_reset = PasswordReset(user)
-            password_reset.send_email()
-            password_reset.save()
-            flash(_('Password reset link sent to %(email)s.', email=user.email), 'success')
+            if user and not user.is_deleted:
+                active_resets = user.get_active_and_recent_password_resets()
+                max_active = current_app.config['XL_AUTH_MAX_ACTIVE_PASSWORD_RESETS']
+                if len(active_resets) < max_active:
+                    password_reset = PasswordReset(user)
+                    password_reset.send_email()
+                    password_reset.save()
+            flash(_('If that account exists, a password reset link has been sent to its '
+                    'email address.'), 'success')
             return redirect(url_for('public.home'))
         else:
             flash_errors(forgot_password_form)

--- a/xl_auth/settings.py
+++ b/xl_auth/settings.py
@@ -5,6 +5,10 @@ import os
 
 from . import __author__, __name__, __version__
 
+# For dev/test. In other environments the env var XL_AUTH_SECRET (which
+# overrides this) must be set, otherwise the server will not start.
+DEFAULT_SECRET_KEY = 'not-so-secret-key'
+
 
 class Config(object):
     """Base configuration."""
@@ -14,7 +18,7 @@ class Config(object):
     APP_NAME = __name__
     APP_VERSION = __version__
     APP_AUTHOR = __author__
-    SECRET_KEY = os.environ.get('XL_AUTH_SECRET', 'secret-key')  # TODO: Change me
+    SECRET_KEY = os.environ.get('XL_AUTH_SECRET', DEFAULT_SECRET_KEY)
     APP_DIR = os.path.abspath(os.path.dirname(__file__))  # This directory.
     PROJECT_ROOT = os.path.abspath(os.path.join(APP_DIR, os.pardir))
     BCRYPT_LOG_ROUNDS = 13

--- a/xl_auth/translations/sv/LC_MESSAGES/messages.po
+++ b/xl_auth/translations/sv/LC_MESSAGES/messages.po
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.2.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 10:27+0200\n"
+"POT-Creation-Date: 2026-08-05 15:23+0200\n"
 "PO-Revision-Date: 2022-06-09 15:36+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
 "Language-Team: sv <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.3\n"
 
 #: tests/end2end/test_collection_editing.py:58 tests/end2end/test_collection_registering.py:54
 msgid "category"
@@ -220,52 +220,42 @@ msgstr "Vidare till tjänsten"
 msgid "Collections"
 msgstr "Sigler"
 
-#: tests/end2end/test_public_logging_in.py:142 xl_auth/public/views.py:116
+#: tests/end2end/test_public_logging_in.py:142 xl_auth/public/views.py:124
 msgid "You are logged out."
 msgstr "Du är utloggad."
 
-#: tests/end2end/test_public_logging_in.py:156 tests/end2end/test_public_logging_in.py:190
-#: tests/forms/test_public_login.py:43 xl_auth/public/forms.py:39
-msgid "Invalid password"
-msgstr "Felaktigt lösenord"
+#: tests/end2end/test_public_logging_in.py:156 tests/end2end/test_public_logging_in.py:173
+#: tests/end2end/test_public_logging_in.py:190 tests/forms/test_public_login.py:28
+#: xl_auth/public/forms.py:41
+msgid "The username or password you entered is incorrect."
+msgstr "Användarnamnet eller lösenordet du angav är felaktigt."
 
-#: tests/end2end/test_public_logging_in.py:173 tests/end2end/test_public_reset_password.py:78
-#: tests/forms/test_public_forgot_password.py:19 tests/forms/test_public_login.py:33
-#: xl_auth/public/forms.py:35 xl_auth/public/forms.py:72
-msgid "Unknown username/email"
-msgstr "Okänd e-postadress/användarnamn"
-
-#: tests/end2end/test_public_reset_password.py:28 tests/end2end/test_public_reset_password.py:151
-#: tests/end2end/test_public_reset_password.py:166 xl_auth/templates/public/home.html:47
+#: tests/end2end/test_public_reset_password.py:28 tests/end2end/test_public_reset_password.py:173
+#: tests/end2end/test_public_reset_password.py:188 xl_auth/templates/public/home.html:47
 msgid "Forgot password?"
 msgstr "Glömt ditt lösenord?"
 
-#: tests/end2end/test_public_reset_password.py:99 tests/forms/test_public_reset_password.py:18
-#: xl_auth/public/forms.py:107
+#: tests/end2end/test_public_reset_password.py:67 xl_auth/public/views.py:85
+msgid "If that account exists, a password reset link has been sent to its email address."
+msgstr "Om kontot finns har en återställningslänk skickats till dess e-postadress."
+
+#: tests/end2end/test_public_reset_password.py:121 tests/forms/test_public_reset_password.py:18
+#: xl_auth/public/forms.py:102
 #, python-format
 msgid "Reset code \"%(code)s\" does not exit"
 msgstr "Återställningsnyckel \"%(code)s\" finns inte"
 
-#: tests/end2end/test_public_reset_password.py:117 tests/forms/test_public_reset_password.py:30
-#: xl_auth/public/forms.py:98
+#: tests/end2end/test_public_reset_password.py:139 tests/forms/test_public_reset_password.py:30
+#: xl_auth/public/forms.py:93
 #, python-format
 msgid "Reset code \"%(code)s\" expired at %(isoformat)s"
 msgstr "Giltighetstiden för återställningsnyckel \"%(code)s\" har gått ut (%(isoformat)s)"
 
-#: tests/end2end/test_public_reset_password.py:141 tests/forms/test_public_reset_password.py:42
-#: xl_auth/public/forms.py:103
+#: tests/end2end/test_public_reset_password.py:163 tests/forms/test_public_reset_password.py:42
+#: xl_auth/public/forms.py:98
 #, python-format
 msgid "Reset code \"%(code)s\" already used (%(isoformat)s)"
 msgstr "Återställningsnyckel \"%(code)s\" har redan förbrukats (%(isoformat)s)"
-
-#: tests/end2end/test_public_reset_password.py:173 tests/forms/test_public_forgot_password.py:46
-#: xl_auth/public/forms.py:65
-msgid ""
-"You already have an active password reset. Please check your email inbox (and your Spam folder) "
-"or try again later."
-msgstr ""
-"Du har redan en aktiv lösenordsåterställning. Vänligen leta i din inkorg (och i mappen för "
-"skräppost) eller försök igen senare."
 
 #: tests/end2end/test_user_deletion.py:21 tests/end2end/test_user_editing.py:25
 #: tests/end2end/test_user_editing.py:75 tests/end2end/test_user_editing.py:116
@@ -339,7 +329,7 @@ msgid "Email already registered"
 msgstr "E-postadressen är redan registrerad"
 
 #: tests/end2end/test_user_editing.py:192 tests/end2end/test_user_editing.py:216
-#: xl_auth/public/forms.py:52 xl_auth/public/forms.py:80 xl_auth/templates/users/home.html:26
+#: xl_auth/public/forms.py:63 xl_auth/public/forms.py:75 xl_auth/templates/users/home.html:26
 #: xl_auth/templates/users/home.html:100 xl_auth/templates/users/inspect.html:131
 #: xl_auth/templates/users/inspect.html:185 xl_auth/user/forms.py:13
 msgid "Email"
@@ -457,10 +447,6 @@ msgstr "Ett sigel måste väljas."
 msgid "Collection ID \"%(collection_id)s\" does not exist"
 msgstr "Sigel med databas-ID \"%(collection_id)s\" existerar inte"
 
-#: tests/forms/test_public_login.py:54 xl_auth/public/forms.py:43
-msgid "User not activated"
-msgstr "Användarkontot ej aktiverat; återställ ditt lösenord"
-
 #: tests/forms/test_user_administer.py:30 xl_auth/user/forms.py:108
 msgid "User does not exist"
 msgstr "Användaren existerar inte"
@@ -552,6 +538,18 @@ msgstr "Klient \"%(name)s\" skapad."
 msgid "Thank you for updating client details for \"%(client_id)s\"."
 msgstr "Inställningar för \"%(client_id)s\" uppdaterade."
 
+#: xl_auth/oauth/grant/models.py:64 xl_auth/oauth/token/models.py:77
+#: xl_auth/templates/oauth/grants/home.html:15 xl_auth/templates/oauth/tokens/home.html:15
+#: xl_auth/templates/users/inspect.html:258
+msgid "Client"
+msgstr "Klient"
+
+#: xl_auth/oauth/grant/models.py:64 xl_auth/oauth/token/models.py:77
+#: xl_auth/templates/oauth/grants/home.html:16 xl_auth/templates/oauth/tokens/home.html:16
+#: xl_auth/templates/users/inspect.html:229 xl_auth/templates/users/inspect.html:261
+msgid "Expires At"
+msgstr "Förfaller"
+
 #: xl_auth/oauth/grant/views.py:39
 #, python-format
 msgid "Successfully deleted OAuth2 Grant token \"%(grant_id)s\"."
@@ -593,21 +591,21 @@ msgstr "Katalogiseringsadmin"
 msgid "--- Select Collection ---"
 msgstr "--- Välj sigel ---"
 
-#: xl_auth/public/forms.py:18 xl_auth/templates/public/home.html:41
+#: xl_auth/public/forms.py:23 xl_auth/templates/public/home.html:41
 msgid "Username"
 msgstr "Användarnamn"
 
-#: xl_auth/public/forms.py:19 xl_auth/public/forms.py:81 xl_auth/templates/public/home.html:43
+#: xl_auth/public/forms.py:24 xl_auth/public/forms.py:76 xl_auth/templates/public/home.html:43
 #: xl_auth/templates/public/reset_password.html:16 xl_auth/templates/users/change_password.html:16
 #: xl_auth/user/forms.py:168
 msgid "Password"
 msgstr "Lösenord"
 
-#: xl_auth/public/forms.py:82 xl_auth/user/forms.py:169
+#: xl_auth/public/forms.py:77 xl_auth/user/forms.py:169
 msgid "Verify password"
 msgstr "Upprepa lösenord"
 
-#: xl_auth/public/forms.py:84 xl_auth/user/forms.py:170
+#: xl_auth/public/forms.py:79 xl_auth/user/forms.py:170
 msgid "Passwords must match"
 msgstr "Lösenorden måste stämma överens"
 
@@ -615,12 +613,7 @@ msgstr "Lösenorden måste stämma överens"
 msgid "You are logged in."
 msgstr "Du har loggat in."
 
-#: xl_auth/public/views.py:78
-#, python-format
-msgid "Password reset link sent to %(email)s."
-msgstr "Återställningslänk skickad till %(email)s."
-
-#: xl_auth/public/views.py:100
+#: xl_auth/public/views.py:108
 #, python-format
 msgid "Password for \"%(username)s\" has been reset."
 msgstr "Lösenordet för \"%(username)s\" har återställts."
@@ -867,16 +860,6 @@ msgstr "Grant-tokens för OAuth2"
 #: xl_auth/templates/users/inspect.html:256
 msgid "ID"
 msgstr "ID"
-
-#: xl_auth/templates/oauth/grants/home.html:15 xl_auth/templates/oauth/tokens/home.html:15
-#: xl_auth/templates/users/inspect.html:258
-msgid "Client"
-msgstr "Klient"
-
-#: xl_auth/templates/oauth/grants/home.html:16 xl_auth/templates/oauth/tokens/home.html:16
-#: xl_auth/templates/users/inspect.html:229 xl_auth/templates/users/inspect.html:261
-msgid "Expires At"
-msgstr "Förfaller"
 
 #: xl_auth/templates/oauth/grants/home.html:28
 msgid "Delete Grant"
@@ -1390,4 +1373,25 @@ msgstr "Användaren \"%(username)s\" har tagits bort."
 
 #~ msgid "Thank you for changing email for \"%(username)s\"."
 #~ msgstr "Epostadress för \"%(username)s\" har ändrats."
+
+#~ msgid "Invalid password"
+#~ msgstr "Felaktigt lösenord"
+
+#~ msgid "Unknown username/email"
+#~ msgstr "Okänd e-postadress/användarnamn"
+
+#~ msgid ""
+#~ "You already have an active password reset. Please"
+#~ " check your email inbox (and your Spam folder)"
+#~ " or try again later."
+#~ msgstr ""
+#~ "Du har redan en aktiv lösenordsåterställning. Vänligen "
+#~ "leta i din inkorg (och i mappen för skräppost)"
+#~ " eller försök igen senare."
+
+#~ msgid "User not activated"
+#~ msgstr "Användarkontot ej aktiverat; återställ ditt lösenord"
+
+#~ msgid "Password reset link sent to %(email)s."
+#~ msgstr "Återställningslänk skickad till %(email)s."
 

--- a/xl_auth/utils.py
+++ b/xl_auth/utils.py
@@ -15,7 +15,12 @@ def flash_errors(form, category='warning'):
     """Flash all errors for a form."""
     for field, errors in form.errors.items():
         for error in errors:
-            flash('{0} - {1}'.format(getattr(form, field).label.text, error), category)
+            # Form-level errors aren't tied to a field so don't flash them with a
+            # "<field label> - " prefix.
+            if field is None:
+                flash(error, category)
+            else:
+                flash('{0} - {1}'.format(getattr(form, field).label.text, error), category)
 
 
 def get_redirect_target():


### PR DESCRIPTION
A few things:

* Most importantly OAuth consent is now keyed to client_id+scope. This still fulfills LXL-1168.
* Refuse to start if `XL_AUTH_SECRET` is not set.
* Provide a generic message on invalid user/password, and on password reset, to prevent user enumeration.
